### PR TITLE
fix(#10): reject login for unverified email accounts

### DIFF
--- a/internal/handler/auth_handler.go
+++ b/internal/handler/auth_handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/signsafe-io/signsafe-api/internal/middleware"
 	"github.com/signsafe-io/signsafe-api/internal/service"
@@ -90,7 +91,11 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 
 	pair, err := h.authSvc.Login(r.Context(), req.Email, req.Password)
 	if err != nil {
-		util.Error(w, http.StatusUnauthorized, "invalid credentials")
+		msg := "invalid credentials"
+		if strings.Contains(err.Error(), "email not verified") {
+			msg = "email not verified"
+		}
+		util.Error(w, http.StatusUnauthorized, msg)
 		return
 	}
 

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -126,6 +126,10 @@ func (s *AuthService) Login(ctx context.Context, email, password string) (*Token
 		return nil, fmt.Errorf("authService.Login: invalid credentials")
 	}
 
+	if !u.EmailVerified {
+		return nil, fmt.Errorf("authService.Login: email not verified")
+	}
+
 	return s.issueTokens(ctx, u)
 }
 


### PR DESCRIPTION
## 변경사항
- `auth_service.go`: Login 시 emailVerified=false면 에러 반환
- `auth_handler.go`: "email not verified" 에러를 401로 매핑

## QA 결과
- 미인증 유저 로그인 시 401 + "email not verified" 반환 확인

Closes #10