### PR TITLE
fix(#12): fix contract status comment (processed → ready)

### DIFF
--- a/migrations/000002_init_contracts.up.sql
+++ b/migrations/000002_init_contracts.up.sql
@@ -7,7 +7,7 @@ CREATE TABLE contracts (
     uploaded_by     VARCHAR(26)  NOT NULL REFERENCES users(id),
     title           VARCHAR(500) NOT NULL,
     status          VARCHAR(50)  NOT NULL DEFAULT 'uploaded',
-    -- status: uploaded | processing | processed | failed
+    -- status: uploaded | processing | ready | failed
     file_path       VARCHAR(1000) NOT NULL,
     file_name       VARCHAR(500) NOT NULL,
     file_size       BIGINT       NOT NULL DEFAULT 0,


### PR DESCRIPTION
## 변경사항
- migration SQL 주석의 status 값 'processed' → 'ready' 수정

## 배경
signsafe-web types/index.ts와 signsafe-ai ingestion worker 모두 'ready'를 사용.
migration 주석만 'processed'로 불일치했던 것을 수정.

Closes #12