### PR TITLE
feat(#14): 회원가입 시 개인 Organization 자동 생성

### DIFF
--- a/internal/handler/auth_handler.go
+++ b/internal/handler/auth_handler.go
@@ -47,8 +47,9 @@ func (h *AuthHandler) Signup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	util.JSON(w, http.StatusCreated, map[string]interface{}{
-		"userId":  result.UserID,
-		"message": "verification email sent",
+		"userId":         result.UserID,
+		"organizationId": result.OrganizationID,
+		"message":        "verification email sent",
 	})
 }
 
@@ -213,21 +214,23 @@ func (h *AuthHandler) GetMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	u, err := h.authSvc.GetMe(r.Context(), userID)
+	result, err := h.authSvc.GetMe(r.Context(), userID)
 	if err != nil {
 		util.Error(w, http.StatusInternalServerError, "failed to fetch user")
 		return
 	}
 
+	u := result.User
 	util.JSON(w, http.StatusOK, map[string]interface{}{
-		"id":            u.ID,
-		"email":         u.Email,
-		"fullName":      u.FullName,
-		"role":          u.Role,
-		"emailVerified": u.EmailVerified,
-		"mfaEnabled":    u.MFAEnabled,
-		"createdAt":     u.CreatedAt,
-		"permissions":   defaultPermissions(u.Role),
+		"id":             u.ID,
+		"email":          u.Email,
+		"fullName":       u.FullName,
+		"role":           u.Role,
+		"emailVerified":  u.EmailVerified,
+		"mfaEnabled":     u.MFAEnabled,
+		"createdAt":      u.CreatedAt,
+		"permissions":    defaultPermissions(u.Role),
+		"organizationId": result.OrganizationID,
 	})
 }
 

--- a/internal/repository/user_repo.go
+++ b/internal/repository/user_repo.go
@@ -185,3 +185,85 @@ func (r *UserRepo) RevokeAllRefreshTokens(ctx context.Context, userID string) er
 	}
 	return nil
 }
+
+// CreateOrganization inserts a new organization.
+func (r *UserRepo) CreateOrganization(ctx context.Context, tx sqlx.ExtContext, org *model.Organization) error {
+	_, err := sqlx.NamedExecContext(ctx, tx, `
+		INSERT INTO organizations (id, name, plan, features, created_at, updated_at)
+		VALUES (:id, :name, :plan, :features, NOW(), NOW())`, org)
+	if err != nil {
+		return fmt.Errorf("userRepo.CreateOrganization: %w", err)
+	}
+	return nil
+}
+
+// CreateUserOrganization inserts a user-organization membership.
+func (r *UserRepo) CreateUserOrganization(ctx context.Context, tx sqlx.ExtContext, uo *model.UserOrganization) error {
+	_, err := sqlx.NamedExecContext(ctx, tx, `
+		INSERT INTO user_organizations (id, user_id, organization_id, role, permissions, joined_at)
+		VALUES (:id, :user_id, :organization_id, :role, :permissions, NOW())`, uo)
+	if err != nil {
+		return fmt.Errorf("userRepo.CreateUserOrganization: %w", err)
+	}
+	return nil
+}
+
+// CreateWithOrg creates a user, their personal organization, and membership in a single transaction.
+func (r *UserRepo) CreateWithOrg(ctx context.Context, u *model.User, org *model.Organization, uo *model.UserOrganization) error {
+	tx, err := r.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("userRepo.CreateWithOrg: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO users (id, email, password_hash, full_name, role,
+		                   email_verified, email_verify_token, email_verify_expires_at,
+		                   created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW())`,
+		u.ID, u.Email, u.PasswordHash, u.FullName, u.Role,
+		u.EmailVerified, u.EmailVerifyToken, u.EmailVerifyExpiresAt,
+	); err != nil {
+		return fmt.Errorf("userRepo.CreateWithOrg: insert user: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO organizations (id, name, plan, features, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, NOW(), NOW())`,
+		org.ID, org.Name, org.Plan, org.Features,
+	); err != nil {
+		return fmt.Errorf("userRepo.CreateWithOrg: insert org: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO user_organizations (id, user_id, organization_id, role, permissions, joined_at)
+		VALUES ($1, $2, $3, $4, $5, NOW())`,
+		uo.ID, uo.UserID, uo.OrganizationID, uo.Role, uo.Permissions,
+	); err != nil {
+		return fmt.Errorf("userRepo.CreateWithOrg: insert user_org: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("userRepo.CreateWithOrg: commit: %w", err)
+	}
+	return nil
+}
+
+// FindOrganizationByUserID returns the first organization a user belongs to.
+func (r *UserRepo) FindOrganizationByUserID(ctx context.Context, userID string) (*model.Organization, error) {
+	var org model.Organization
+	err := r.db.GetContext(ctx, &org, `
+		SELECT o.*
+		FROM organizations o
+		JOIN user_organizations uo ON uo.organization_id = o.id
+		WHERE uo.user_id = $1
+		ORDER BY uo.joined_at ASC
+		LIMIT 1`, userID)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("userRepo.FindOrganizationByUserID: %w", err)
+	}
+	return &org, nil
+}

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -49,7 +49,8 @@ type SignupRequest struct {
 
 // SignupResult holds the result after signup.
 type SignupResult struct {
-	UserID string
+	UserID         string
+	OrganizationID string
 }
 
 // Signup creates a new user account.
@@ -81,12 +82,27 @@ func (s *AuthService) Signup(ctx context.Context, req SignupRequest) (*SignupRes
 		EmailVerifyExpiresAt: &expires,
 	}
 
-	if err := s.userRepo.Create(ctx, u); err != nil {
+	org := &model.Organization{
+		ID:       util.NewID(),
+		Name:     req.FullName + "'s Organization",
+		Plan:     "free",
+		Features: "{}",
+	}
+
+	uo := &model.UserOrganization{
+		ID:             util.NewID(),
+		UserID:         u.ID,
+		OrganizationID: org.ID,
+		Role:           "admin",
+		Permissions:    "[]",
+	}
+
+	if err := s.userRepo.CreateWithOrg(ctx, u, org, uo); err != nil {
 		return nil, fmt.Errorf("authService.Signup: %w", err)
 	}
 
 	// TODO: send verification email (email service not yet implemented)
-	return &SignupResult{UserID: u.ID}, nil
+	return &SignupResult{UserID: u.ID, OrganizationID: org.ID}, nil
 }
 
 // VerifyEmail confirms a user's email address.
@@ -237,8 +253,14 @@ func (s *AuthService) ResetPassword(ctx context.Context, token, newPassword stri
 	return nil
 }
 
-// GetMe returns the full user details.
-func (s *AuthService) GetMe(ctx context.Context, userID string) (*model.User, error) {
+// GetMeResult holds user details together with the primary organization.
+type GetMeResult struct {
+	User           *model.User
+	OrganizationID string
+}
+
+// GetMe returns the full user details with their primary organization ID.
+func (s *AuthService) GetMe(ctx context.Context, userID string) (*GetMeResult, error) {
 	u, err := s.userRepo.FindByID(ctx, userID)
 	if err != nil {
 		return nil, fmt.Errorf("authService.GetMe: %w", err)
@@ -246,7 +268,18 @@ func (s *AuthService) GetMe(ctx context.Context, userID string) (*model.User, er
 	if u == nil {
 		return nil, fmt.Errorf("authService.GetMe: user not found")
 	}
-	return u, nil
+
+	org, err := s.userRepo.FindOrganizationByUserID(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("authService.GetMe: find org: %w", err)
+	}
+
+	orgID := ""
+	if org != nil {
+		orgID = org.ID
+	}
+
+	return &GetMeResult{User: u, OrganizationID: orgID}, nil
 }
 
 // --- internal helpers ---


### PR DESCRIPTION
## 변경사항
- Signup()에서 user, organization, user_organizations을 단일 DB 트랜잭션으로 생성
- UserRepo에 CreateWithOrg(), FindOrganizationByUserID() 메서드 추가
- POST /auth/signup 응답에 organizationId 필드 추가
- GetMe() 반환 타입을 GetMeResult로 변경하여 organizationId 포함
- GET /users/me 응답에 organizationId 포함

## 수정된 버그
신규 가입 사용자에게 organization이 없어 계약 업로드/조회가 불가능했던 문제 해결.
프론트엔드 /contracts 페이지에서 organizationId를 올바르게 사용할 수 있게 됨.

## QA 결과
- go build ./... 성공 (컴파일 에러 없음)
- POST /auth/signup → organizationId 포함한 응답
- GET /users/me → organizationId 포함한 응답

Closes #14