### PR TITLE
feat(#18): GET /contracts/:contractId 단건 조회 엔드포인트 추가

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -120,6 +120,7 @@ func main() {
 			r.Get("/", contractHandler.List)
 			r.Post("/", contractHandler.Upload)
 			r.Route("/{contractId}", func(r chi.Router) {
+				r.Get("/", contractHandler.Get)
 				r.Get("/clauses", contractHandler.ListClauses)
 				r.Get("/snippets", contractHandler.GetSnippets)
 				r.Post("/risk-analyses", analysisHandler.CreateAnalysis)

--- a/internal/handler/contract_handler.go
+++ b/internal/handler/contract_handler.go
@@ -93,6 +93,21 @@ func (h *ContractHandler) List(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// Get handles GET /contracts/{contractId}
+func (h *ContractHandler) Get(w http.ResponseWriter, r *http.Request) {
+	contractID := chi.URLParam(r, "contractId")
+	c, err := h.contractSvc.GetContract(r.Context(), contractID)
+	if err != nil {
+		util.Error(w, http.StatusInternalServerError, "failed to get contract")
+		return
+	}
+	if c == nil {
+		util.Error(w, http.StatusNotFound, "contract not found")
+		return
+	}
+	util.JSON(w, http.StatusOK, c)
+}
+
 // GetIngestionJob handles GET /ingestion-jobs/{jobId}
 func (h *ContractHandler) GetIngestionJob(w http.ResponseWriter, r *http.Request) {
 	jobID := chi.URLParam(r, "jobId")

--- a/internal/service/contract_service.go
+++ b/internal/service/contract_service.go
@@ -121,6 +121,15 @@ func (s *ContractService) ListContracts(ctx context.Context, orgID string, page,
 	return contracts, total, nil
 }
 
+// GetContract returns a single contract by ID.
+func (s *ContractService) GetContract(ctx context.Context, contractID string) (*model.Contract, error) {
+	c, err := s.repo.FindContractByID(ctx, contractID)
+	if err != nil {
+		return nil, fmt.Errorf("contractService.GetContract: %w", err)
+	}
+	return c, nil
+}
+
 // ListClauses returns all clauses for a contract.
 func (s *ContractService) ListClauses(ctx context.Context, contractID string) ([]model.Clause, error) {
 	clauses, err := s.repo.ListClausesByContractID(ctx, contractID)


### PR DESCRIPTION
## 변경사항
- `contract_service.go`: `GetContract(ctx, contractID)` 메서드 추가
- `contract_handler.go`: `Get` HTTP 핸들러 추가 — `GET /contracts/{contractId}`
- `main.go`: 라우터에 `r.Get("/", contractHandler.Get)` 등록

## QA 결과
- `go build ./...` 통과

## 배경
프론트엔드 계약 상세 페이지(`contracts/[id]/page.tsx`)에서 계약 단건을 조회하여
`contract.title`, `contract.filePath` 등을 표시할 수 없는 문제 해결.

Closes #18