### PR TITLE
fix(#23): CORS 와일드카드 설정 시 빈 Access-Control-Allow-Origin 반환 수정

### DIFF
--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -13,7 +13,13 @@ func CORS(allowedOrigins []string) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			origin := r.Header.Get("Origin")
 
-			if len(allowed) == 0 || allowed["*"] || allowed[origin] {
+			if len(allowed) == 0 || allowed["*"] {
+				if origin != "" {
+					w.Header().Set("Access-Control-Allow-Origin", origin)
+				} else {
+					w.Header().Set("Access-Control-Allow-Origin", "*")
+				}
+			} else if allowed[origin] {
 				w.Header().Set("Access-Control-Allow-Origin", origin)
 			}
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")


### PR DESCRIPTION
## 변경사항
- `ALLOWED_ORIGINS=*` 설정 시 Origin 헤더 없는 요청에도 `Access-Control-Allow-Origin: *` 올바르게 반환
- 특정 origin이 허용된 경우 기존 동작 유지

## QA 결과
- [x] go build ./... 통과
- [x] go vet ./... 통과

Closes #23