### PR TITLE
fix(#25): Signup 에러 응답 상태코드 구분 (409 vs 500)

### DIFF
--- a/internal/handler/auth_handler.go
+++ b/internal/handler/auth_handler.go
@@ -42,7 +42,11 @@ func (h *AuthHandler) Signup(w http.ResponseWriter, r *http.Request) {
 		FullName: req.FullName,
 	})
 	if err != nil {
-		util.Error(w, http.StatusConflict, err.Error())
+		if strings.Contains(err.Error(), "email already registered") {
+			util.Error(w, http.StatusConflict, "email already registered")
+		} else {
+			util.Error(w, http.StatusInternalServerError, "signup failed")
+		}
 		return
 	}
 


### PR DESCRIPTION
## 변경사항
- 이메일 중복 오류: 409 Conflict 반환
- DB 오류 등 내부 서버 오류: 500 Internal Server Error 반환
- 기존에는 모든 에러가 409로 반환되어 클라이언트가 오류 원인 파악 불가

## QA 결과
- [x] go build ./... 통과
- [x] go vet ./... 통과

Closes #25