### PR TITLE
fix(#27): 분석 요청 성공 후 Redis 분산 락 즉시 해제

### DIFF
--- a/internal/service/analysis_service.go
+++ b/internal/service/analysis_service.go
@@ -68,6 +68,11 @@ func (s *AnalysisService) CreateAnalysis(ctx context.Context, contractID, userID
 		return "", fmt.Errorf("analysisService.CreateAnalysis: queue: %w", err)
 	}
 
+	// Release the lock immediately after successful enqueue.
+	// The lock only needed to prevent duplicate in-flight requests;
+	// the AI worker will handle deduplication at the job level.
+	_ = s.cache.Delete(ctx, lockKey)
+
 	return analysisID, nil
 }
 


### PR DESCRIPTION
## 변경사항
- 큐 발행 성공 후 Redis 락을 즉시 해제
- 기존: 락이 10분간 유지되어 분석 완료 후에도 재분석 불가
- 동시 중복 요청 방지 목적은 유지 (락 획득 경쟁 시 거부)

## QA 결과
- [x] go build ./... 통과
- [x] go vet ./... 통과

Closes #27