### PR TITLE
fix(#29): evidence_handler 불필요한 topKStr 변수 및 strconv import 제거

### DIFF
--- a/internal/handler/evidence_handler.go
+++ b/internal/handler/evidence_handler.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
-	"strconv"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/signsafe-io/signsafe-api/internal/service"
@@ -51,8 +50,6 @@ func (h *EvidenceHandler) RetrieveEvidence(w http.ResponseWriter, r *http.Reques
 	if req.TopK == 0 {
 		req.TopK = 5
 	}
-	topKStr := strconv.Itoa(req.TopK)
-	_ = topKStr
 
 	if err := h.evidenceSvc.RetrieveEvidence(r.Context(), evidenceSetID, req.TopK, req.FilterParams); err != nil {
 		util.Error(w, http.StatusInternalServerError, err.Error())


### PR DESCRIPTION
## 변경사항
- `RetrieveEvidence` 핸들러에서 사용되지 않는 `topKStr` 변수 제거
- `_ = topKStr` 무시 코드 제거
- 불필요해진 `strconv` import 제거

## QA 결과
- [x] go build ./... 통과
- [x] go vet ./... 통과

Closes #29