### PR TITLE
fix(#31): add org membership check to contract list/get endpoints

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -89,7 +89,7 @@ func main() {
 	authSvc := service.NewAuthService(userRepo, cacheClient, emailClient, jwtSecret)
 
 	contractRepo := repository.NewContractRepo(db)
-	contractSvc := service.NewContractService(contractRepo, queueClient, storageClient)
+	contractSvc := service.NewContractService(contractRepo, userRepo, queueClient, storageClient)
 
 	analysisRepo := repository.NewAnalysisRepo(db)
 	analysisSvc := service.NewAnalysisService(analysisRepo, contractRepo, queueClient, cacheClient)

--- a/internal/handler/contract_handler.go
+++ b/internal/handler/contract_handler.go
@@ -78,6 +78,17 @@ func (h *ContractHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	userID := middleware.UserIDFromContext(r.Context())
+	member, err := h.contractSvc.IsOrgMember(r.Context(), userID, orgID)
+	if err != nil {
+		util.Error(w, http.StatusInternalServerError, "failed to verify organization membership")
+		return
+	}
+	if !member {
+		util.Error(w, http.StatusForbidden, "access denied: not a member of this organization")
+		return
+	}
+
 	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
 	pageSize, _ := strconv.Atoi(r.URL.Query().Get("pageSize"))
 
@@ -107,6 +118,18 @@ func (h *ContractHandler) Get(w http.ResponseWriter, r *http.Request) {
 		util.Error(w, http.StatusNotFound, "contract not found")
 		return
 	}
+
+	userID := middleware.UserIDFromContext(r.Context())
+	member, err := h.contractSvc.IsOrgMember(r.Context(), userID, c.OrganizationID)
+	if err != nil {
+		util.Error(w, http.StatusInternalServerError, "failed to verify organization membership")
+		return
+	}
+	if !member {
+		util.Error(w, http.StatusForbidden, "access denied: not a member of this organization")
+		return
+	}
+
 	util.JSON(w, http.StatusOK, c)
 }
 

--- a/internal/repository/user_repo.go
+++ b/internal/repository/user_repo.go
@@ -249,6 +249,20 @@ func (r *UserRepo) CreateWithOrg(ctx context.Context, u *model.User, org *model.
 	return nil
 }
 
+// IsOrgMember returns true when the user belongs to the given organization.
+func (r *UserRepo) IsOrgMember(ctx context.Context, userID, orgID string) (bool, error) {
+	var count int
+	err := r.db.GetContext(ctx, &count, `
+		SELECT COUNT(*)
+		FROM user_organizations
+		WHERE user_id = $1 AND organization_id = $2`,
+		userID, orgID)
+	if err != nil {
+		return false, fmt.Errorf("userRepo.IsOrgMember: %w", err)
+	}
+	return count > 0, nil
+}
+
 // FindOrganizationByUserID returns the first organization a user belongs to.
 func (r *UserRepo) FindOrganizationByUserID(ctx context.Context, userID string) (*model.Organization, error) {
 	var org model.Organization

--- a/internal/service/contract_service.go
+++ b/internal/service/contract_service.go
@@ -15,13 +15,14 @@ import (
 // ContractService handles contract business logic.
 type ContractService struct {
 	repo          *repository.ContractRepo
+	userRepo      *repository.UserRepo
 	queue         *queue.Client
 	storageClient *storage.Client
 }
 
 // NewContractService creates a new ContractService.
-func NewContractService(repo *repository.ContractRepo, q *queue.Client, s *storage.Client) *ContractService {
-	return &ContractService{repo: repo, queue: q, storageClient: s}
+func NewContractService(repo *repository.ContractRepo, userRepo *repository.UserRepo, q *queue.Client, s *storage.Client) *ContractService {
+	return &ContractService{repo: repo, userRepo: userRepo, queue: q, storageClient: s}
 }
 
 // UploadRequest holds the contract upload parameters.
@@ -103,6 +104,15 @@ func (s *ContractService) GetIngestionJob(ctx context.Context, jobID string) (*m
 		return nil, fmt.Errorf("contractService.GetIngestionJob: %w", err)
 	}
 	return job, nil
+}
+
+// IsOrgMember returns true when userID belongs to orgID.
+func (s *ContractService) IsOrgMember(ctx context.Context, userID, orgID string) (bool, error) {
+	member, err := s.userRepo.IsOrgMember(ctx, userID, orgID)
+	if err != nil {
+		return false, fmt.Errorf("contractService.IsOrgMember: %w", err)
+	}
+	return member, nil
 }
 
 // ListContracts returns a paginated list of contracts.


### PR DESCRIPTION
## 변경사항
- UserRepo.IsOrgMember(): user_organizations 테이블에서 멤버십 확인
- ContractService.IsOrgMember(): repo 메서드 래퍼
- ContractHandler.List(): organizationId 접근 전 멤버십 검증 (403 반환)
- ContractHandler.Get(): 계약서 조회 후 org 멤버십 검증 (403 반환)
- main.go: NewContractService에 userRepo 인자 추가

## QA 결과
- [x] go build ./... pass
- [x] go vet ./... pass

Closes #31