### PR TITLE
fix(#33): strip port from RemoteAddr before storing in INET column

### DIFF
--- a/internal/handler/audit_handler.go
+++ b/internal/handler/audit_handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"net"
 	"net/http"
 
 	"github.com/signsafe-io/signsafe-api/internal/middleware"
@@ -39,7 +40,11 @@ func (h *AuditHandler) CreateAuditEvent(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Strip port from RemoteAddr so it can be stored in a PostgreSQL INET column.
 	ipAddr := r.RemoteAddr
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		ipAddr = host
+	}
 	userAgent := r.UserAgent()
 
 	auditReq := service.CreateAuditEventRequest{


### PR DESCRIPTION
## 변경사항
- audit_handler.go: net.SplitHostPort()로 host만 추출
- 포트를 제거하여 PostgreSQL INET 타입에 안전하게 저장
- 파싱 실패 시 원본 RemoteAddr gracefully 유지

## QA 결과
- [x] go build ./... pass
- [x] go vet ./... pass

Closes #33