### PR TITLE
fix(#35): GetFile 엔드포인트에 org 멤버십 검사 추가

### DIFF
--- a/internal/handler/contract_handler.go
+++ b/internal/handler/contract_handler.go
@@ -176,6 +176,17 @@ func (h *ContractHandler) GetFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	userID := middleware.UserIDFromContext(r.Context())
+	member, err := h.contractSvc.IsOrgMember(r.Context(), userID, c.OrganizationID)
+	if err != nil {
+		util.Error(w, http.StatusInternalServerError, "failed to verify organization membership")
+		return
+	}
+	if !member {
+		util.Error(w, http.StatusForbidden, "access denied: not a member of this organization")
+		return
+	}
+
 	body, contentType, err := h.contractSvc.GetFile(r.Context(), contractID)
 	if err != nil {
 		util.Error(w, http.StatusInternalServerError, "failed to retrieve file")


### PR DESCRIPTION
## 변경사항
- GetFile 핸들러에 IsOrgMember 검사 추가
- 계약 파일 다운로드 시 org 비멤버는 403 반환
- Get 핸들러와 동일한 보안 패턴 적용

## QA 결과
- go build ./... 통과
- go vet ./... 통과

Closes #35