### PR TITLE
fix(#36): CreateAnalysis 핸들러에서 DB/큐 오류 시 500 반환

### DIFF
--- a/internal/handler/analysis_handler.go
+++ b/internal/handler/analysis_handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/signsafe-io/signsafe-api/internal/middleware"
@@ -27,7 +28,11 @@ func (h *AnalysisHandler) CreateAnalysis(w http.ResponseWriter, r *http.Request)
 
 	analysisID, err := h.analysisSvc.CreateAnalysis(r.Context(), contractID, userID)
 	if err != nil {
-		util.Error(w, http.StatusConflict, err.Error())
+		if strings.Contains(err.Error(), "analysis already running") {
+			util.Error(w, http.StatusConflict, "analysis already running for this contract")
+		} else {
+			util.Error(w, http.StatusInternalServerError, "failed to create analysis")
+		}
 		return
 	}
 


### PR DESCRIPTION
## 변경사항
- 분석 생성 시 서비스 오류 구분 처리
- 'analysis already running' → 409 (기존과 동일)
- DB 저장 실패, 큐 발행 실패 등 내부 오류 → 500
- strings 패키지 import 추가

## QA 결과
- go build ./... 통과
- go vet ./... 통과

Closes #36