### PR TITLE
feat(#37): GET /contracts/{contractId}/risk-analyses 엔드포인트 추가

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -141,6 +141,7 @@ func main() {
 				r.Get("/file", contractHandler.GetFile)
 				r.Get("/clauses", contractHandler.ListClauses)
 				r.Get("/snippets", contractHandler.GetSnippets)
+				r.Get("/risk-analyses", analysisHandler.GetLatestAnalysis)
 				r.Post("/risk-analyses", analysisHandler.CreateAnalysis)
 			})
 		})

--- a/internal/handler/analysis_handler.go
+++ b/internal/handler/analysis_handler.go
@@ -21,6 +21,26 @@ func NewAnalysisHandler(analysisSvc *service.AnalysisService) *AnalysisHandler {
 	return &AnalysisHandler{analysisSvc: analysisSvc}
 }
 
+// GetLatestAnalysis handles GET /contracts/{contractId}/risk-analyses
+func (h *AnalysisHandler) GetLatestAnalysis(w http.ResponseWriter, r *http.Request) {
+	contractID := chi.URLParam(r, "contractId")
+
+	analysis, results, err := h.analysisSvc.GetLatestAnalysis(r.Context(), contractID)
+	if err != nil {
+		util.Error(w, http.StatusInternalServerError, "failed to get analysis")
+		return
+	}
+	if analysis == nil {
+		util.Error(w, http.StatusNotFound, "no analysis found for this contract")
+		return
+	}
+
+	util.JSON(w, http.StatusOK, map[string]interface{}{
+		"analysis":      analysis,
+		"clauseResults": results,
+	})
+}
+
 // CreateAnalysis handles POST /contracts/{contractId}/risk-analyses
 func (h *AnalysisHandler) CreateAnalysis(w http.ResponseWriter, r *http.Request) {
 	contractID := chi.URLParam(r, "contractId")

--- a/internal/repository/analysis_repo.go
+++ b/internal/repository/analysis_repo.go
@@ -32,6 +32,23 @@ func (r *AnalysisRepo) CreateAnalysis(ctx context.Context, a *model.RiskAnalysis
 	return nil
 }
 
+// FindLatestAnalysisByContractID retrieves the most recent risk analysis for a contract.
+func (r *AnalysisRepo) FindLatestAnalysisByContractID(ctx context.Context, contractID string) (*model.RiskAnalysis, error) {
+	var a model.RiskAnalysis
+	err := r.db.GetContext(ctx, &a, `
+		SELECT * FROM risk_analyses
+		WHERE contract_id = $1
+		ORDER BY created_at DESC
+		LIMIT 1`, contractID)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("analysisRepo.FindLatestAnalysisByContractID: %w", err)
+	}
+	return &a, nil
+}
+
 // FindAnalysisByID retrieves a risk analysis by ID.
 func (r *AnalysisRepo) FindAnalysisByID(ctx context.Context, id string) (*model.RiskAnalysis, error) {
 	var a model.RiskAnalysis

--- a/internal/service/analysis_service.go
+++ b/internal/service/analysis_service.go
@@ -35,6 +35,24 @@ func NewAnalysisService(
 	}
 }
 
+// GetLatestAnalysis returns the most recent analysis for a contract with its clause results.
+func (s *AnalysisService) GetLatestAnalysis(ctx context.Context, contractID string) (*model.RiskAnalysis, []repository.ClauseResultWithEvidence, error) {
+	a, err := s.analysisRepo.FindLatestAnalysisByContractID(ctx, contractID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("analysisService.GetLatestAnalysis: %w", err)
+	}
+	if a == nil {
+		return nil, nil, nil
+	}
+
+	results, err := s.analysisRepo.ListClauseResultsWithEvidenceByAnalysisID(ctx, a.ID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("analysisService.GetLatestAnalysis: clause results: %w", err)
+	}
+
+	return a, results, nil
+}
+
 // CreateAnalysis creates a risk analysis and enqueues the job.
 func (s *AnalysisService) CreateAnalysis(ctx context.Context, contractID, userID string) (string, error) {
 	// Distributed lock to prevent duplicate analyses.


### PR DESCRIPTION
## 변경사항
- analysisRepo에 FindLatestAnalysisByContractID 메서드 추가
- analysisService에 GetLatestAnalysis 메서드 추가 (분석 + clauseResults)
- analysisHandler에 GetLatestAnalysis GET 핸들러 추가
- main.go 라우터에 GET /contracts/{contractId}/risk-analyses 등록
- 분석 없을 시 404 반환

## QA 결과
- go build ./... 통과
- go vet ./... 통과

Closes #37