### PR TITLE
feat(#42): DELETE /contracts/{id} endpoint

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -138,6 +138,7 @@ func main() {
 			r.Post("/", contractHandler.Upload)
 			r.Route("/{contractId}", func(r chi.Router) {
 				r.Get("/", contractHandler.Get)
+				r.Delete("/", contractHandler.Delete)
 				r.Get("/file", contractHandler.GetFile)
 				r.Get("/clauses", contractHandler.ListClauses)
 				r.Get("/snippets", contractHandler.GetSnippets)

--- a/internal/handler/contract_handler.go
+++ b/internal/handler/contract_handler.go
@@ -204,6 +204,26 @@ func (h *ContractHandler) GetFile(w http.ResponseWriter, r *http.Request) {
 	_, _ = io.Copy(w, body)
 }
 
+// Delete handles DELETE /contracts/{contractId}
+func (h *ContractHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	contractID := chi.URLParam(r, "contractId")
+	userID := middleware.UserIDFromContext(r.Context())
+
+	if err := h.contractSvc.DeleteContract(r.Context(), contractID, userID); err != nil {
+		switch {
+		case err.Error() == "contractService.DeleteContract: contract not found":
+			util.Error(w, http.StatusNotFound, "contract not found")
+		case err.Error() == "contractService.DeleteContract: access denied":
+			util.Error(w, http.StatusForbidden, "access denied: not a member of this organization")
+		default:
+			util.Error(w, http.StatusInternalServerError, "failed to delete contract: "+err.Error())
+		}
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // GetSnippets handles GET /contracts/{contractId}/snippets
 func (h *ContractHandler) GetSnippets(w http.ResponseWriter, r *http.Request) {
 	contractID := chi.URLParam(r, "contractId")

--- a/internal/repository/contract_repo.go
+++ b/internal/repository/contract_repo.go
@@ -107,6 +107,25 @@ func (r *ContractRepo) ListClausesByContractID(ctx context.Context, contractID s
 	return clauses, nil
 }
 
+// DeleteContract removes a contract by ID scoped to the organization.
+// Cascade deletes on clauses, ingestion_jobs, and risk_analyses are handled by the DB.
+func (r *ContractRepo) DeleteContract(ctx context.Context, contractID, orgID string) error {
+	result, err := r.db.ExecContext(ctx,
+		`DELETE FROM contracts WHERE id = $1 AND organization_id = $2`,
+		contractID, orgID)
+	if err != nil {
+		return fmt.Errorf("contractRepo.DeleteContract: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("contractRepo.DeleteContract rows affected: %w", err)
+	}
+	if n == 0 {
+		return fmt.Errorf("contractRepo.DeleteContract: not found or access denied")
+	}
+	return nil
+}
+
 // GetSnippet returns clauses that overlap with the given page and offset range.
 func (r *ContractRepo) GetSnippet(ctx context.Context, contractID string, page, startOffset, endOffset int) ([]model.Clause, error) {
 	var clauses []model.Clause

--- a/internal/service/contract_service.go
+++ b/internal/service/contract_service.go
@@ -158,6 +158,37 @@ func (s *ContractService) GetSnippets(ctx context.Context, contractID string, pa
 	return clauses, nil
 }
 
+// DeleteContract deletes a contract and its associated storage file.
+// requestedBy must be a member of the contract's organization.
+func (s *ContractService) DeleteContract(ctx context.Context, contractID, requestedBy string) error {
+	c, err := s.repo.FindContractByID(ctx, contractID)
+	if err != nil {
+		return fmt.Errorf("contractService.DeleteContract: %w", err)
+	}
+	if c == nil {
+		return fmt.Errorf("contractService.DeleteContract: contract not found")
+	}
+
+	member, err := s.userRepo.IsOrgMember(ctx, requestedBy, c.OrganizationID)
+	if err != nil {
+		return fmt.Errorf("contractService.DeleteContract: check membership: %w", err)
+	}
+	if !member {
+		return fmt.Errorf("contractService.DeleteContract: access denied")
+	}
+
+	// Delete from storage (best-effort; DB row is the authoritative record).
+	if err := s.storageClient.Delete(ctx, c.FilePath); err != nil {
+		return fmt.Errorf("contractService.DeleteContract: storage: %w", err)
+	}
+
+	if err := s.repo.DeleteContract(ctx, contractID, c.OrganizationID); err != nil {
+		return fmt.Errorf("contractService.DeleteContract: db: %w", err)
+	}
+
+	return nil
+}
+
 // GetFile retrieves the raw file bytes for a contract from SeaweedFS.
 // Returns the ReadCloser (caller must close it), the mime type, and any error.
 func (s *ContractService) GetFile(ctx context.Context, contractID string) (io.ReadCloser, string, error) {


### PR DESCRIPTION
## 변경사항
- `internal/repository/contract_repo.go`: `DeleteContract(ctx, contractID, orgID)` 추가
- `internal/service/contract_service.go`: `DeleteContract(ctx, contractID, requestedBy)` 추가
- `internal/handler/contract_handler.go`: `Delete` 핸들러 추가 (204 No Content)
- `cmd/server/main.go`: DELETE 라우트 등록

## QA 결과
- go build ./... 통과
- go vet ./... 통과

Closes #42