### PR TITLE
feat(#43): PATCH /contracts/{id} endpoint

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -139,6 +139,7 @@ func main() {
 			r.Route("/{contractId}", func(r chi.Router) {
 				r.Get("/", contractHandler.Get)
 				r.Delete("/", contractHandler.Delete)
+				r.Patch("/", contractHandler.Update)
 				r.Get("/file", contractHandler.GetFile)
 				r.Get("/clauses", contractHandler.ListClauses)
 				r.Get("/snippets", contractHandler.GetSnippets)

--- a/internal/handler/contract_handler.go
+++ b/internal/handler/contract_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -151,6 +152,28 @@ func (h *ContractHandler) GetIngestionJob(w http.ResponseWriter, r *http.Request
 // ListClauses handles GET /contracts/{contractId}/clauses
 func (h *ContractHandler) ListClauses(w http.ResponseWriter, r *http.Request) {
 	contractID := chi.URLParam(r, "contractId")
+
+	c, err := h.contractSvc.GetContract(r.Context(), contractID)
+	if err != nil {
+		util.Error(w, http.StatusInternalServerError, "failed to get contract")
+		return
+	}
+	if c == nil {
+		util.Error(w, http.StatusNotFound, "contract not found")
+		return
+	}
+
+	userID := middleware.UserIDFromContext(r.Context())
+	member, err := h.contractSvc.IsOrgMember(r.Context(), userID, c.OrganizationID)
+	if err != nil {
+		util.Error(w, http.StatusInternalServerError, "failed to verify organization membership")
+		return
+	}
+	if !member {
+		util.Error(w, http.StatusForbidden, "access denied: not a member of this organization")
+		return
+	}
+
 	clauses, err := h.contractSvc.ListClauses(r.Context(), contractID)
 	if err != nil {
 		util.Error(w, http.StatusInternalServerError, "failed to list clauses")
@@ -224,9 +247,79 @@ func (h *ContractHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// updateContractBody is the JSON body accepted by PATCH /contracts/{contractId}.
+type updateContractBody struct {
+	Title        *string `json:"title"`
+	Tags         *string `json:"tags"`
+	Parties      *string `json:"parties"`
+	Language     *string `json:"language"`
+	ContractType *string `json:"contractType"`
+	SignedAt     *string `json:"signedAt"`
+	ExpiresAt    *string `json:"expiresAt"`
+}
+
+// Update handles PATCH /contracts/{contractId}
+func (h *ContractHandler) Update(w http.ResponseWriter, r *http.Request) {
+	contractID := chi.URLParam(r, "contractId")
+	userID := middleware.UserIDFromContext(r.Context())
+
+	var body updateContractBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		util.Error(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	req := service.UpdateContractRequest{
+		Title:        body.Title,
+		Tags:         body.Tags,
+		Parties:      body.Parties,
+		Language:     body.Language,
+		ContractType: body.ContractType,
+		SignedAt:     body.SignedAt,
+		ExpiresAt:    body.ExpiresAt,
+	}
+
+	updated, err := h.contractSvc.UpdateContract(r.Context(), contractID, userID, req)
+	if err != nil {
+		switch {
+		case err.Error() == "contractService.UpdateContract: contract not found":
+			util.Error(w, http.StatusNotFound, "contract not found")
+		case err.Error() == "contractService.UpdateContract: access denied":
+			util.Error(w, http.StatusForbidden, "access denied: not a member of this organization")
+		default:
+			util.Error(w, http.StatusInternalServerError, "failed to update contract: "+err.Error())
+		}
+		return
+	}
+
+	util.JSON(w, http.StatusOK, updated)
+}
+
 // GetSnippets handles GET /contracts/{contractId}/snippets
 func (h *ContractHandler) GetSnippets(w http.ResponseWriter, r *http.Request) {
 	contractID := chi.URLParam(r, "contractId")
+
+	c, err := h.contractSvc.GetContract(r.Context(), contractID)
+	if err != nil {
+		util.Error(w, http.StatusInternalServerError, "failed to get contract")
+		return
+	}
+	if c == nil {
+		util.Error(w, http.StatusNotFound, "contract not found")
+		return
+	}
+
+	userID := middleware.UserIDFromContext(r.Context())
+	member, err := h.contractSvc.IsOrgMember(r.Context(), userID, c.OrganizationID)
+	if err != nil {
+		util.Error(w, http.StatusInternalServerError, "failed to verify organization membership")
+		return
+	}
+	if !member {
+		util.Error(w, http.StatusForbidden, "access denied: not a member of this organization")
+		return
+	}
+
 	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
 	startOffset, _ := strconv.Atoi(r.URL.Query().Get("startOffset"))
 	endOffset, _ := strconv.Atoi(r.URL.Query().Get("endOffset"))

--- a/internal/repository/contract_repo.go
+++ b/internal/repository/contract_repo.go
@@ -4,10 +4,24 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/signsafe-io/signsafe-api/internal/model"
 )
+
+// ContractUpdate holds the optional fields that can be patched on a contract.
+// Only non-nil fields are written to the DB.
+type ContractUpdate struct {
+	Title        *string
+	Tags         *string
+	Parties      *string
+	Language     *string
+	ContractType *string
+	SignedAt     *time.Time
+	ExpiresAt    *time.Time
+}
 
 // ContractRepo handles DB operations for contracts, ingestion jobs, and clauses.
 type ContractRepo struct {
@@ -124,6 +138,74 @@ func (r *ContractRepo) DeleteContract(ctx context.Context, contractID, orgID str
 		return fmt.Errorf("contractRepo.DeleteContract: not found or access denied")
 	}
 	return nil
+}
+
+// UpdateContract applies a partial update to a contract.
+// Only non-nil fields in updates are written; at least one field must be set.
+func (r *ContractRepo) UpdateContract(ctx context.Context, contractID string, updates ContractUpdate) (*model.Contract, error) {
+	setClauses := make([]string, 0, 8)
+	args := make([]interface{}, 0, 9)
+	argIdx := 1
+
+	if updates.Title != nil {
+		setClauses = append(setClauses, fmt.Sprintf("title = $%d", argIdx))
+		args = append(args, *updates.Title)
+		argIdx++
+	}
+	if updates.Tags != nil {
+		setClauses = append(setClauses, fmt.Sprintf("tags = $%d", argIdx))
+		args = append(args, *updates.Tags)
+		argIdx++
+	}
+	if updates.Parties != nil {
+		setClauses = append(setClauses, fmt.Sprintf("parties = $%d", argIdx))
+		args = append(args, *updates.Parties)
+		argIdx++
+	}
+	if updates.Language != nil {
+		setClauses = append(setClauses, fmt.Sprintf("language = $%d", argIdx))
+		args = append(args, *updates.Language)
+		argIdx++
+	}
+	if updates.ContractType != nil {
+		setClauses = append(setClauses, fmt.Sprintf("contract_type = $%d", argIdx))
+		args = append(args, *updates.ContractType)
+		argIdx++
+	}
+	if updates.SignedAt != nil {
+		setClauses = append(setClauses, fmt.Sprintf("signed_at = $%d", argIdx))
+		args = append(args, *updates.SignedAt)
+		argIdx++
+	}
+	if updates.ExpiresAt != nil {
+		setClauses = append(setClauses, fmt.Sprintf("expires_at = $%d", argIdx))
+		args = append(args, *updates.ExpiresAt)
+		argIdx++
+	}
+
+	if len(setClauses) == 0 {
+		return nil, fmt.Errorf("contractRepo.UpdateContract: no fields to update")
+	}
+
+	setClauses = append(setClauses, fmt.Sprintf("updated_at = $%d", argIdx))
+	args = append(args, time.Now())
+	argIdx++
+
+	args = append(args, contractID)
+	query := fmt.Sprintf(
+		`UPDATE contracts SET %s WHERE id = $%d RETURNING *`,
+		strings.Join(setClauses, ", "),
+		argIdx,
+	)
+
+	var c model.Contract
+	if err := r.db.GetContext(ctx, &c, query, args...); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("contractRepo.UpdateContract: not found")
+		}
+		return nil, fmt.Errorf("contractRepo.UpdateContract: %w", err)
+	}
+	return &c, nil
 }
 
 // GetSnippet returns clauses that overlap with the given page and offset range.

--- a/internal/service/contract_service.go
+++ b/internal/service/contract_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/signsafe-io/signsafe-api/internal/model"
 	"github.com/signsafe-io/signsafe-api/internal/queue"
@@ -156,6 +157,68 @@ func (s *ContractService) GetSnippets(ctx context.Context, contractID string, pa
 		return nil, fmt.Errorf("contractService.GetSnippets: %w", err)
 	}
 	return clauses, nil
+}
+
+// UpdateContractRequest holds the optional fields for a partial contract update.
+type UpdateContractRequest struct {
+	Title        *string
+	Tags         *string
+	Parties      *string
+	Language     *string
+	ContractType *string
+	SignedAt     *string
+	ExpiresAt    *string
+}
+
+// UpdateContract applies a partial update to a contract.
+// requestedBy must be a member of the contract's organization.
+func (s *ContractService) UpdateContract(ctx context.Context, contractID, requestedBy string, req UpdateContractRequest) (*model.Contract, error) {
+	c, err := s.repo.FindContractByID(ctx, contractID)
+	if err != nil {
+		return nil, fmt.Errorf("contractService.UpdateContract: %w", err)
+	}
+	if c == nil {
+		return nil, fmt.Errorf("contractService.UpdateContract: contract not found")
+	}
+
+	member, err := s.userRepo.IsOrgMember(ctx, requestedBy, c.OrganizationID)
+	if err != nil {
+		return nil, fmt.Errorf("contractService.UpdateContract: check membership: %w", err)
+	}
+	if !member {
+		return nil, fmt.Errorf("contractService.UpdateContract: access denied")
+	}
+
+	updates := repository.ContractUpdate{
+		Title:        req.Title,
+		Tags:         req.Tags,
+		Parties:      req.Parties,
+		Language:     req.Language,
+		ContractType: req.ContractType,
+	}
+
+	if req.SignedAt != nil {
+		t, err := time.Parse(time.RFC3339, *req.SignedAt)
+		if err != nil {
+			return nil, fmt.Errorf("contractService.UpdateContract: invalid signedAt: %w", err)
+		}
+		updates.SignedAt = &t
+	}
+
+	if req.ExpiresAt != nil {
+		t, err := time.Parse(time.RFC3339, *req.ExpiresAt)
+		if err != nil {
+			return nil, fmt.Errorf("contractService.UpdateContract: invalid expiresAt: %w", err)
+		}
+		updates.ExpiresAt = &t
+	}
+
+	updated, err := s.repo.UpdateContract(ctx, contractID, updates)
+	if err != nil {
+		return nil, fmt.Errorf("contractService.UpdateContract: db: %w", err)
+	}
+
+	return updated, nil
 }
 
 // DeleteContract deletes a contract and its associated storage file.


### PR DESCRIPTION
## 변경사항
- `internal/repository/contract_repo.go`: `ContractUpdate` 구조체 및 `UpdateContract()` 추가 (동적 partial update)
- `internal/service/contract_service.go`: `UpdateContractRequest` 및 `UpdateContract()` 추가
- `internal/handler/contract_handler.go`: `Update` 핸들러 추가 (200 OK + 업데이트된 계약서)
- `cmd/server/main.go`: PATCH 라우트 등록

## QA 결과
- go build ./... 통과
- go vet ./... 통과

Closes #43