### PR TITLE
fix(#49): CreateOverride original_risk_level 버그 수정

### DIFF
--- a/internal/service/analysis_service.go
+++ b/internal/service/analysis_service.go
@@ -122,11 +122,8 @@ func (s *AnalysisService) CreateOverride(ctx context.Context, analysisID, clause
 		return nil, fmt.Errorf("analysisService.CreateOverride: clause result not found")
 	}
 
-	// Use the current effective risk level as original.
+	// Always use the AI-assessed risk level as the original, regardless of prior overrides.
 	originalLevel := cr.RiskLevel
-	if cr.OverriddenRiskLevel != nil {
-		originalLevel = *cr.OverriddenRiskLevel
-	}
 
 	o := &model.RiskOverride{
 		ID:                util.NewID(),


### PR DESCRIPTION
## 변경사항

AnalysisService.CreateOverride에서 original_risk_level 저장 로직 버그 수정.

**버그**: 이전 오버라이드가 존재할 경우 cr.OverriddenRiskLevel (이미 수정된 값)을 originalLevel로 사용.
**수정**: 항상 cr.RiskLevel (AI 원본 평가값)을 사용.

이로써 동일 조항에 여러 번 오버라이드가 발생해도 original_risk_level은 항상 AI 분석 결과를 가리킨다.

## QA 결과

- go build ./... 통과
- go vet ./... 통과

Closes #49