### PR TITLE
fix(#51,#52,#53,#54): validate inputs, fix override security, hide internal errors

### DIFF
--- a/internal/handler/analysis_handler.go
+++ b/internal/handler/analysis_handler.go
@@ -103,7 +103,18 @@ func (h *AnalysisHandler) CreateOverride(w http.ResponseWriter, r *http.Request)
 
 	override, err := h.analysisSvc.CreateOverride(r.Context(), analysisID, req.ClauseResultID, req.NewRiskLevel, req.Reason, userID)
 	if err != nil {
-		util.Error(w, http.StatusInternalServerError, err.Error())
+		switch {
+		case strings.Contains(err.Error(), "invalid risk level"):
+			util.Error(w, http.StatusBadRequest, "invalid risk level: must be HIGH, MEDIUM, or LOW")
+		case strings.Contains(err.Error(), "analysis not found"):
+			util.Error(w, http.StatusNotFound, "analysis not found")
+		case strings.Contains(err.Error(), "clause result not found"):
+			util.Error(w, http.StatusNotFound, "clause result not found")
+		case strings.Contains(err.Error(), "does not belong to analysis"):
+			util.Error(w, http.StatusForbidden, "clause result does not belong to this analysis")
+		default:
+			util.Error(w, http.StatusInternalServerError, "failed to create override")
+		}
 		return
 	}
 

--- a/internal/handler/auth_handler.go
+++ b/internal/handler/auth_handler.go
@@ -35,6 +35,10 @@ func (h *AuthHandler) Signup(w http.ResponseWriter, r *http.Request) {
 		util.Error(w, http.StatusBadRequest, "email, password, and fullName are required")
 		return
 	}
+	if len(req.Password) < 8 {
+		util.Error(w, http.StatusBadRequest, "password must be at least 8 characters")
+		return
+	}
 
 	result, err := h.authSvc.Signup(r.Context(), service.SignupRequest{
 		Email:    req.Email,
@@ -199,6 +203,10 @@ func (h *AuthHandler) ResetPassword(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Token == "" || req.NewPassword == "" {
 		util.Error(w, http.StatusBadRequest, "token and newPassword are required")
+		return
+	}
+	if len(req.NewPassword) < 8 {
+		util.Error(w, http.StatusBadRequest, "password must be at least 8 characters")
 		return
 	}
 

--- a/internal/handler/contract_handler.go
+++ b/internal/handler/contract_handler.go
@@ -61,7 +61,7 @@ func (h *ContractHandler) Upload(w http.ResponseWriter, r *http.Request) {
 		File:           file,
 	})
 	if err != nil {
-		util.Error(w, http.StatusInternalServerError, "upload failed: "+err.Error())
+		util.Error(w, http.StatusInternalServerError, "upload failed")
 		return
 	}
 

--- a/internal/service/analysis_service.go
+++ b/internal/service/analysis_service.go
@@ -112,14 +112,40 @@ func (s *AnalysisService) GetAnalysis(ctx context.Context, analysisID string) (*
 	return a, results, nil
 }
 
+// allowedRiskLevels is the set of valid values for newRiskLevel in an override.
+var allowedRiskLevels = map[string]struct{}{
+	"HIGH":   {},
+	"MEDIUM": {},
+	"LOW":    {},
+}
+
 // CreateOverride stores a risk override for a clause result.
+// It verifies that clauseResultID belongs to the given analysisID.
 func (s *AnalysisService) CreateOverride(ctx context.Context, analysisID, clauseResultID, newRiskLevel, reason, userID string) (*model.RiskOverride, error) {
+	if _, ok := allowedRiskLevels[newRiskLevel]; !ok {
+		return nil, fmt.Errorf("analysisService.CreateOverride: invalid risk level %q (must be HIGH, MEDIUM, or LOW)", newRiskLevel)
+	}
+
+	// Verify the analysis exists.
+	a, err := s.analysisRepo.FindAnalysisByID(ctx, analysisID)
+	if err != nil {
+		return nil, fmt.Errorf("analysisService.CreateOverride: find analysis: %w", err)
+	}
+	if a == nil {
+		return nil, fmt.Errorf("analysisService.CreateOverride: analysis not found")
+	}
+
 	cr, err := s.analysisRepo.FindClauseResultByID(ctx, clauseResultID)
 	if err != nil {
 		return nil, fmt.Errorf("analysisService.CreateOverride: find clause result: %w", err)
 	}
 	if cr == nil {
 		return nil, fmt.Errorf("analysisService.CreateOverride: clause result not found")
+	}
+
+	// Verify the clause result belongs to the specified analysis.
+	if cr.AnalysisID != analysisID {
+		return nil, fmt.Errorf("analysisService.CreateOverride: clause result does not belong to analysis")
 	}
 
 	// Always use the AI-assessed risk level as the original, regardless of prior overrides.


### PR DESCRIPTION
## 변경사항
- **#51**: CreateOverride가 analysisId와 clauseResultId 소속 관계 검증 — 다른 분석의 clause에 임의 override 방지
- **#52**: 서버사이드 비밀번호 최소 길이 8자 검증 (signup, reset-password)
- **#53**: newRiskLevel 유효값(HIGH/MEDIUM/LOW) 검증 — 임의 문자열 DB 저장 방지
- **#54**: 계약 업로드 실패 시 내부 에러 상세 정보를 클라이언트에 노출하지 않음

## QA 결과
- go build ./... 통과
- go vet ./... 통과

Closes #51
Closes #52
Closes #53
Closes #54