### PR TITLE
fix(#56,#57): fix GetSnippet swapped SQL params and DeleteContract storage best-effort

### DIFF
--- a/internal/repository/contract_repo.go
+++ b/internal/repository/contract_repo.go
@@ -215,7 +215,7 @@ func (r *ContractRepo) GetSnippet(ctx context.Context, contractID string, page, 
 		SELECT * FROM clauses
 		WHERE contract_id = $1
 		  AND page_start <= $2 AND page_end >= $2
-		  AND start_offset <= $4 AND end_offset >= $3
+		  AND start_offset <= $3 AND end_offset >= $4
 		ORDER BY clause_index`,
 		contractID, page, startOffset, endOffset)
 	if err != nil {

--- a/internal/service/contract_service.go
+++ b/internal/service/contract_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"time"
 
 	"github.com/signsafe-io/signsafe-api/internal/model"
@@ -241,8 +242,10 @@ func (s *ContractService) DeleteContract(ctx context.Context, contractID, reques
 	}
 
 	// Delete from storage (best-effort; DB row is the authoritative record).
+	// Storage failures are logged but must not block DB deletion.
 	if err := s.storageClient.Delete(ctx, c.FilePath); err != nil {
-		return fmt.Errorf("contractService.DeleteContract: storage: %w", err)
+		slog.Warn("contractService.DeleteContract: storage delete failed (best-effort)",
+			"contractId", contractID, "filePath", c.FilePath, "error", err)
 	}
 
 	if err := s.repo.DeleteContract(ctx, contractID, c.OrganizationID); err != nil {


### PR DESCRIPTION
## 변경사항
- **#56**: `GetSnippet` SQL WHERE 절에서 `$3`/`$4` 순서 버그 수정
  - 기존: `start_offset <= $4 AND end_offset >= $3` (endOffset과 startOffset이 뒤바뀜)
  - 수정: `start_offset <= $3 AND end_offset >= $4` (올바른 파라미터 순서)
- **#57**: `DeleteContract` storage 삭제 실패 시 DB 삭제 차단 버그 수정
  - 기존: storage 오류 시 에러 반환 → DB 삭제 불가
  - 수정: storage 실패 시 경고 로그만 남기고 DB 삭제 계속 진행 (주석의 best-effort 의도와 일치)

## QA 결과
- `go build ./...` 통과
- `go vet ./...` 통과

Closes #56
Closes #57