### PR TITLE
fix(#58): add Redis-based rate limiting to /auth/login and /auth/signup

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
@@ -117,10 +118,13 @@ func main() {
 	r.Get("/health", healthHandler)
 
 	// Auth routes (no auth middleware)
+	// Rate limiters: login/signup are brute-force targets.
+	loginLimiter := middleware.RateLimiter(cacheClient, 10, 1*time.Minute)
+	signupLimiter := middleware.RateLimiter(cacheClient, 5, 1*time.Minute)
 	r.Route("/auth", func(r chi.Router) {
-		r.Post("/signup", authHandler.Signup)
+		r.With(signupLimiter).Post("/signup", authHandler.Signup)
 		r.Post("/verify-email", authHandler.VerifyEmail)
-		r.Post("/login", authHandler.Login)
+		r.With(loginLimiter).Post("/login", authHandler.Login)
 		r.Post("/refresh", authHandler.Refresh)
 		r.Post("/logout", authHandler.Logout)
 		r.Post("/password/forgot", authHandler.ForgotPassword)

--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -63,6 +63,18 @@ func (c *Client) SetNX(ctx context.Context, key string, value interface{}, ttl t
 	return ok, nil
 }
 
+// Incr atomically increments a counter key and sets its TTL on first creation.
+// Returns the new counter value.
+func (c *Client) Incr(ctx context.Context, key string, ttl time.Duration) (int64, error) {
+	pipe := c.rdb.Pipeline()
+	incrCmd := pipe.Incr(ctx, key)
+	pipe.Expire(ctx, key, ttl)
+	if _, err := pipe.Exec(ctx); err != nil {
+		return 0, fmt.Errorf("cache.Incr: %w", err)
+	}
+	return incrCmd.Val(), nil
+}
+
 // Close shuts down the Redis client.
 func (c *Client) Close() error {
 	return c.rdb.Close()

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -1,0 +1,60 @@
+package middleware
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/signsafe-io/signsafe-api/internal/cache"
+)
+
+// RateLimiter returns a middleware that limits requests per IP per endpoint.
+// limit is the maximum number of requests allowed per window.
+// window is the duration of the sliding window.
+// On Redis failure the middleware fails open (allows the request).
+func RateLimiter(cacheClient *cache.Client, limit int64, window time.Duration) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ip := clientIP(r)
+			// Normalise path to avoid cache key collisions with path parameters.
+			path := r.URL.Path
+			key := fmt.Sprintf("ratelimit:%s:%s", path, ip)
+
+			count, err := cacheClient.Incr(r.Context(), key, window)
+			if err != nil {
+				// Fail open — do not block requests on Redis errors.
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if count > limit {
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Retry-After", fmt.Sprintf("%d", int(window.Seconds())))
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = w.Write([]byte(`{"error":"too many requests, please try again later"}`))
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// clientIP extracts the real client IP from X-Forwarded-For or RemoteAddr.
+func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		// Use the first IP in the chain (original client).
+		parts := strings.Split(xff, ",")
+		ip := strings.TrimSpace(parts[0])
+		if ip != "" {
+			return ip
+		}
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}


### PR DESCRIPTION
## 변경사항
- `cache.Client.Incr()` 추가: Redis pipeline으로 원자적 카운터 증가 + TTL 설정
- `middleware.RateLimiter()` 추가: IP 기반 슬라이딩 윈도우 rate limiter
  - X-Forwarded-For 또는 RemoteAddr에서 클라이언트 IP 추출
  - Redis 오류 시 fail-open (합법적인 트래픽 차단 방지)
- `/auth/login`: IP당 10 req/분 제한
- `/auth/signup`: IP당 5 req/분 제한  
- 한도 초과 시 HTTP 429 + Retry-After 헤더 반환

## QA 결과
- `go build ./...` 통과
- `go vet ./...` 통과

Closes #58