### PR TITLE
fix(#61): add org membership check to GetLatestAnalysis and GetAnalysis (IDOR)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -93,7 +93,7 @@ func main() {
 	contractSvc := service.NewContractService(contractRepo, userRepo, queueClient, storageClient)
 
 	analysisRepo := repository.NewAnalysisRepo(db)
-	analysisSvc := service.NewAnalysisService(analysisRepo, contractRepo, queueClient, cacheClient)
+	analysisSvc := service.NewAnalysisService(analysisRepo, contractRepo, userRepo, queueClient, cacheClient)
 
 	evidenceRepo := repository.NewEvidenceRepo(db)
 	evidenceSvc := service.NewEvidenceService(evidenceRepo, queueClient)

--- a/internal/handler/analysis_handler.go
+++ b/internal/handler/analysis_handler.go
@@ -24,10 +24,18 @@ func NewAnalysisHandler(analysisSvc *service.AnalysisService) *AnalysisHandler {
 // GetLatestAnalysis handles GET /contracts/{contractId}/risk-analyses
 func (h *AnalysisHandler) GetLatestAnalysis(w http.ResponseWriter, r *http.Request) {
 	contractID := chi.URLParam(r, "contractId")
+	userID := middleware.UserIDFromContext(r.Context())
 
-	analysis, results, err := h.analysisSvc.GetLatestAnalysis(r.Context(), contractID)
+	analysis, results, err := h.analysisSvc.GetLatestAnalysis(r.Context(), contractID, userID)
 	if err != nil {
-		util.Error(w, http.StatusInternalServerError, "failed to get analysis")
+		switch {
+		case strings.Contains(err.Error(), "contract not found"):
+			util.Error(w, http.StatusNotFound, "contract not found")
+		case strings.Contains(err.Error(), "access denied"):
+			util.Error(w, http.StatusForbidden, "access denied: not a member of this organization")
+		default:
+			util.Error(w, http.StatusInternalServerError, "failed to get analysis")
+		}
 		return
 	}
 	if analysis == nil {
@@ -65,10 +73,16 @@ func (h *AnalysisHandler) CreateAnalysis(w http.ResponseWriter, r *http.Request)
 // GetAnalysis handles GET /risk-analyses/{analysisId}
 func (h *AnalysisHandler) GetAnalysis(w http.ResponseWriter, r *http.Request) {
 	analysisID := chi.URLParam(r, "analysisId")
+	userID := middleware.UserIDFromContext(r.Context())
 
-	analysis, results, err := h.analysisSvc.GetAnalysis(r.Context(), analysisID)
+	analysis, results, err := h.analysisSvc.GetAnalysis(r.Context(), analysisID, userID)
 	if err != nil {
-		util.Error(w, http.StatusInternalServerError, "failed to get analysis")
+		switch {
+		case strings.Contains(err.Error(), "access denied"):
+			util.Error(w, http.StatusForbidden, "access denied: not a member of this organization")
+		default:
+			util.Error(w, http.StatusInternalServerError, "failed to get analysis")
+		}
 		return
 	}
 	if analysis == nil {

--- a/internal/service/analysis_service.go
+++ b/internal/service/analysis_service.go
@@ -16,6 +16,7 @@ import (
 type AnalysisService struct {
 	analysisRepo *repository.AnalysisRepo
 	contractRepo *repository.ContractRepo
+	userRepo     *repository.UserRepo
 	queue        *queue.Client
 	cache        *cache.Client
 }
@@ -24,19 +25,38 @@ type AnalysisService struct {
 func NewAnalysisService(
 	analysisRepo *repository.AnalysisRepo,
 	contractRepo *repository.ContractRepo,
+	userRepo *repository.UserRepo,
 	q *queue.Client,
 	c *cache.Client,
 ) *AnalysisService {
 	return &AnalysisService{
 		analysisRepo: analysisRepo,
 		contractRepo: contractRepo,
+		userRepo:     userRepo,
 		queue:        q,
 		cache:        c,
 	}
 }
 
 // GetLatestAnalysis returns the most recent analysis for a contract with its clause results.
-func (s *AnalysisService) GetLatestAnalysis(ctx context.Context, contractID string) (*model.RiskAnalysis, []repository.ClauseResultWithEvidence, error) {
+// userID is used to verify that the caller is a member of the contract's organization.
+func (s *AnalysisService) GetLatestAnalysis(ctx context.Context, contractID, userID string) (*model.RiskAnalysis, []repository.ClauseResultWithEvidence, error) {
+	// Verify the contract exists and the caller is a member of its org.
+	c, err := s.contractRepo.FindContractByID(ctx, contractID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("analysisService.GetLatestAnalysis: find contract: %w", err)
+	}
+	if c == nil {
+		return nil, nil, fmt.Errorf("analysisService.GetLatestAnalysis: contract not found")
+	}
+	member, err := s.userRepo.IsOrgMember(ctx, userID, c.OrganizationID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("analysisService.GetLatestAnalysis: check membership: %w", err)
+	}
+	if !member {
+		return nil, nil, fmt.Errorf("analysisService.GetLatestAnalysis: access denied")
+	}
+
 	a, err := s.analysisRepo.FindLatestAnalysisByContractID(ctx, contractID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("analysisService.GetLatestAnalysis: %w", err)
@@ -95,13 +115,30 @@ func (s *AnalysisService) CreateAnalysis(ctx context.Context, contractID, userID
 }
 
 // GetAnalysis returns a risk analysis with its clause results (including evidence set IDs).
-func (s *AnalysisService) GetAnalysis(ctx context.Context, analysisID string) (*model.RiskAnalysis, []repository.ClauseResultWithEvidence, error) {
+// userID is used to verify that the caller is a member of the analysis's contract organization.
+func (s *AnalysisService) GetAnalysis(ctx context.Context, analysisID, userID string) (*model.RiskAnalysis, []repository.ClauseResultWithEvidence, error) {
 	a, err := s.analysisRepo.FindAnalysisByID(ctx, analysisID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("analysisService.GetAnalysis: %w", err)
 	}
 	if a == nil {
 		return nil, nil, nil
+	}
+
+	// Verify the caller belongs to the contract's org.
+	c, err := s.contractRepo.FindContractByID(ctx, a.ContractID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("analysisService.GetAnalysis: find contract: %w", err)
+	}
+	if c == nil {
+		return nil, nil, fmt.Errorf("analysisService.GetAnalysis: contract not found")
+	}
+	member, err := s.userRepo.IsOrgMember(ctx, userID, c.OrganizationID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("analysisService.GetAnalysis: check membership: %w", err)
+	}
+	if !member {
+		return nil, nil, fmt.Errorf("analysisService.GetAnalysis: access denied")
 	}
 
 	results, err := s.analysisRepo.ListClauseResultsWithEvidenceByAnalysisID(ctx, analysisID)


### PR DESCRIPTION
## 변경사항
- `AnalysisService`에 `userRepo` 추가하여 org 멤버십 검증 가능하게 변경
- **GetLatestAnalysis**: contractId → organization → 멤버십 확인 후 분석 결과 반환
  - 비멤버: 403 Forbidden
  - 계약서 없음: 404 Not Found
- **GetAnalysis**: analysisId → contractId → organization → 멤버십 확인
  - 비멤버: 403 Forbidden
- 두 핸들러 모두 인증된 userID를 서비스에 전달하도록 수정
- `NewAnalysisService` 시그니처에 `userRepo` 파라미터 추가

## 보안 영향
수정 전: JWT만 있으면 타 조직의 계약 분석 결과 조회 가능 (IDOR)
수정 후: 본인 조직 소속 계약의 분석만 조회 가능

## QA 결과
- `go build ./...` 통과
- `go vet ./...` 통과

Closes #61