### PR TITLE
fix(#63): IDOR 취약점 수정 - ingestion job, evidence set, analysis 엔드포인트 org 멤버십 검증 추가

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -96,7 +96,7 @@ func main() {
 	analysisSvc := service.NewAnalysisService(analysisRepo, contractRepo, userRepo, queueClient, cacheClient)
 
 	evidenceRepo := repository.NewEvidenceRepo(db)
-	evidenceSvc := service.NewEvidenceService(evidenceRepo, queueClient)
+	evidenceSvc := service.NewEvidenceService(evidenceRepo, analysisRepo, contractRepo, userRepo, queueClient)
 
 	auditRepo := repository.NewAuditRepo(db)
 	auditSvc := service.NewAuditService(auditRepo)

--- a/internal/handler/analysis_handler.go
+++ b/internal/handler/analysis_handler.go
@@ -56,9 +56,14 @@ func (h *AnalysisHandler) CreateAnalysis(w http.ResponseWriter, r *http.Request)
 
 	analysisID, err := h.analysisSvc.CreateAnalysis(r.Context(), contractID, userID)
 	if err != nil {
-		if strings.Contains(err.Error(), "analysis already running") {
+		switch {
+		case strings.Contains(err.Error(), "analysis already running"):
 			util.Error(w, http.StatusConflict, "analysis already running for this contract")
-		} else {
+		case strings.Contains(err.Error(), "contract not found"):
+			util.Error(w, http.StatusNotFound, "contract not found")
+		case strings.Contains(err.Error(), "access denied"):
+			util.Error(w, http.StatusForbidden, "access denied: not a member of this organization")
+		default:
 			util.Error(w, http.StatusInternalServerError, "failed to create analysis")
 		}
 		return
@@ -126,6 +131,8 @@ func (h *AnalysisHandler) CreateOverride(w http.ResponseWriter, r *http.Request)
 			util.Error(w, http.StatusNotFound, "clause result not found")
 		case strings.Contains(err.Error(), "does not belong to analysis"):
 			util.Error(w, http.StatusForbidden, "clause result does not belong to this analysis")
+		case strings.Contains(err.Error(), "access denied"):
+			util.Error(w, http.StatusForbidden, "access denied: not a member of this organization")
 		default:
 			util.Error(w, http.StatusInternalServerError, "failed to create override")
 		}

--- a/internal/handler/contract_handler.go
+++ b/internal/handler/contract_handler.go
@@ -137,8 +137,14 @@ func (h *ContractHandler) Get(w http.ResponseWriter, r *http.Request) {
 // GetIngestionJob handles GET /ingestion-jobs/{jobId}
 func (h *ContractHandler) GetIngestionJob(w http.ResponseWriter, r *http.Request) {
 	jobID := chi.URLParam(r, "jobId")
-	job, err := h.contractSvc.GetIngestionJob(r.Context(), jobID)
+	userID := middleware.UserIDFromContext(r.Context())
+
+	job, err := h.contractSvc.GetIngestionJob(r.Context(), jobID, userID)
 	if err != nil {
+		if err.Error() == "contractService.GetIngestionJob: access denied" {
+			util.Error(w, http.StatusForbidden, "access denied: not a member of this organization")
+			return
+		}
 		util.Error(w, http.StatusInternalServerError, "failed to get ingestion job")
 		return
 	}

--- a/internal/handler/evidence_handler.go
+++ b/internal/handler/evidence_handler.go
@@ -3,8 +3,10 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/signsafe-io/signsafe-api/internal/middleware"
 	"github.com/signsafe-io/signsafe-api/internal/service"
 	"github.com/signsafe-io/signsafe-api/internal/util"
 )
@@ -22,9 +24,14 @@ func NewEvidenceHandler(evidenceSvc *service.EvidenceService) *EvidenceHandler {
 // GetEvidenceSet handles GET /evidence-sets/{evidenceSetId}
 func (h *EvidenceHandler) GetEvidenceSet(w http.ResponseWriter, r *http.Request) {
 	evidenceSetID := chi.URLParam(r, "evidenceSetId")
+	userID := middleware.UserIDFromContext(r.Context())
 
-	es, err := h.evidenceSvc.GetEvidenceSet(r.Context(), evidenceSetID)
+	es, err := h.evidenceSvc.GetEvidenceSet(r.Context(), evidenceSetID, userID)
 	if err != nil {
+		if strings.Contains(err.Error(), "access denied") {
+			util.Error(w, http.StatusForbidden, "access denied: not a member of this organization")
+			return
+		}
 		util.Error(w, http.StatusInternalServerError, "failed to get evidence set")
 		return
 	}
@@ -38,6 +45,7 @@ func (h *EvidenceHandler) GetEvidenceSet(w http.ResponseWriter, r *http.Request)
 // RetrieveEvidence handles POST /evidence-sets/{evidenceSetId}/retrieve
 func (h *EvidenceHandler) RetrieveEvidence(w http.ResponseWriter, r *http.Request) {
 	evidenceSetID := chi.URLParam(r, "evidenceSetId")
+	userID := middleware.UserIDFromContext(r.Context())
 
 	var req struct {
 		TopK         int    `json:"topK"`
@@ -51,7 +59,15 @@ func (h *EvidenceHandler) RetrieveEvidence(w http.ResponseWriter, r *http.Reques
 		req.TopK = 5
 	}
 
-	if err := h.evidenceSvc.RetrieveEvidence(r.Context(), evidenceSetID, req.TopK, req.FilterParams); err != nil {
+	if err := h.evidenceSvc.RetrieveEvidence(r.Context(), evidenceSetID, req.TopK, req.FilterParams, userID); err != nil {
+		if strings.Contains(err.Error(), "access denied") {
+			util.Error(w, http.StatusForbidden, "access denied: not a member of this organization")
+			return
+		}
+		if strings.Contains(err.Error(), "evidence set not found") {
+			util.Error(w, http.StatusNotFound, "evidence set not found")
+			return
+		}
 		util.Error(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/service/analysis_service.go
+++ b/internal/service/analysis_service.go
@@ -74,7 +74,24 @@ func (s *AnalysisService) GetLatestAnalysis(ctx context.Context, contractID, use
 }
 
 // CreateAnalysis creates a risk analysis and enqueues the job.
+// userID must be a member of the contract's organization.
 func (s *AnalysisService) CreateAnalysis(ctx context.Context, contractID, userID string) (string, error) {
+	// Verify the contract exists and the caller is a member of its org.
+	c, err := s.contractRepo.FindContractByID(ctx, contractID)
+	if err != nil {
+		return "", fmt.Errorf("analysisService.CreateAnalysis: find contract: %w", err)
+	}
+	if c == nil {
+		return "", fmt.Errorf("analysisService.CreateAnalysis: contract not found")
+	}
+	member, err := s.userRepo.IsOrgMember(ctx, userID, c.OrganizationID)
+	if err != nil {
+		return "", fmt.Errorf("analysisService.CreateAnalysis: check membership: %w", err)
+	}
+	if !member {
+		return "", fmt.Errorf("analysisService.CreateAnalysis: access denied")
+	}
+
 	// Distributed lock to prevent duplicate analyses.
 	lockKey := fmt.Sprintf("analysis:lock:%s", contractID)
 	acquired, err := s.cache.SetNX(ctx, lockKey, userID, 10*time.Minute)
@@ -157,7 +174,8 @@ var allowedRiskLevels = map[string]struct{}{
 }
 
 // CreateOverride stores a risk override for a clause result.
-// It verifies that clauseResultID belongs to the given analysisID.
+// It verifies that clauseResultID belongs to the given analysisID and
+// that the caller is a member of the analysis's contract organization.
 func (s *AnalysisService) CreateOverride(ctx context.Context, analysisID, clauseResultID, newRiskLevel, reason, userID string) (*model.RiskOverride, error) {
 	if _, ok := allowedRiskLevels[newRiskLevel]; !ok {
 		return nil, fmt.Errorf("analysisService.CreateOverride: invalid risk level %q (must be HIGH, MEDIUM, or LOW)", newRiskLevel)
@@ -170,6 +188,22 @@ func (s *AnalysisService) CreateOverride(ctx context.Context, analysisID, clause
 	}
 	if a == nil {
 		return nil, fmt.Errorf("analysisService.CreateOverride: analysis not found")
+	}
+
+	// Verify the caller belongs to the contract's org.
+	c, err := s.contractRepo.FindContractByID(ctx, a.ContractID)
+	if err != nil {
+		return nil, fmt.Errorf("analysisService.CreateOverride: find contract: %w", err)
+	}
+	if c == nil {
+		return nil, fmt.Errorf("analysisService.CreateOverride: contract not found")
+	}
+	member, err := s.userRepo.IsOrgMember(ctx, userID, c.OrganizationID)
+	if err != nil {
+		return nil, fmt.Errorf("analysisService.CreateOverride: check membership: %w", err)
+	}
+	if !member {
+		return nil, fmt.Errorf("analysisService.CreateOverride: access denied")
 	}
 
 	cr, err := s.analysisRepo.FindClauseResultByID(ctx, clauseResultID)

--- a/internal/service/contract_service.go
+++ b/internal/service/contract_service.go
@@ -100,11 +100,32 @@ func (s *ContractService) Upload(ctx context.Context, req UploadRequest) (*Uploa
 }
 
 // GetIngestionJob returns the current status of an ingestion job.
-func (s *ContractService) GetIngestionJob(ctx context.Context, jobID string) (*model.IngestionJob, error) {
+// requestedBy must be a member of the job's contract organization.
+func (s *ContractService) GetIngestionJob(ctx context.Context, jobID, requestedBy string) (*model.IngestionJob, error) {
 	job, err := s.repo.FindIngestionJobByID(ctx, jobID)
 	if err != nil {
 		return nil, fmt.Errorf("contractService.GetIngestionJob: %w", err)
 	}
+	if job == nil {
+		return nil, nil
+	}
+
+	// Verify the caller belongs to the job's contract organization.
+	c, err := s.repo.FindContractByID(ctx, job.ContractID)
+	if err != nil {
+		return nil, fmt.Errorf("contractService.GetIngestionJob: find contract: %w", err)
+	}
+	if c == nil {
+		return nil, fmt.Errorf("contractService.GetIngestionJob: contract not found")
+	}
+	member, err := s.userRepo.IsOrgMember(ctx, requestedBy, c.OrganizationID)
+	if err != nil {
+		return nil, fmt.Errorf("contractService.GetIngestionJob: check membership: %w", err)
+	}
+	if !member {
+		return nil, fmt.Errorf("contractService.GetIngestionJob: access denied")
+	}
+
 	return job, nil
 }
 

--- a/internal/service/evidence_service.go
+++ b/internal/service/evidence_service.go
@@ -12,32 +12,99 @@ import (
 // EvidenceService handles evidence set business logic.
 type EvidenceService struct {
 	evidenceRepo *repository.EvidenceRepo
+	analysisRepo *repository.AnalysisRepo
+	contractRepo *repository.ContractRepo
+	userRepo     *repository.UserRepo
 	queue        *queue.Client
 }
 
 // NewEvidenceService creates a new EvidenceService.
-func NewEvidenceService(evidenceRepo *repository.EvidenceRepo, q *queue.Client) *EvidenceService {
-	return &EvidenceService{evidenceRepo: evidenceRepo, queue: q}
+func NewEvidenceService(
+	evidenceRepo *repository.EvidenceRepo,
+	analysisRepo *repository.AnalysisRepo,
+	contractRepo *repository.ContractRepo,
+	userRepo *repository.UserRepo,
+	q *queue.Client,
+) *EvidenceService {
+	return &EvidenceService{
+		evidenceRepo: evidenceRepo,
+		analysisRepo: analysisRepo,
+		contractRepo: contractRepo,
+		userRepo:     userRepo,
+		queue:        q,
+	}
+}
+
+// checkEvidenceSetAccess verifies the caller is a member of the organization
+// that owns the contract associated with the evidence set.
+func (s *EvidenceService) checkEvidenceSetAccess(ctx context.Context, es *model.EvidenceSet, userID string) error {
+	// evidence_set → clause_result → analysis → contract → org
+	cr, err := s.analysisRepo.FindClauseResultByID(ctx, es.ClauseResultID)
+	if err != nil {
+		return fmt.Errorf("find clause result: %w", err)
+	}
+	if cr == nil {
+		return fmt.Errorf("clause result not found")
+	}
+
+	a, err := s.analysisRepo.FindAnalysisByID(ctx, cr.AnalysisID)
+	if err != nil {
+		return fmt.Errorf("find analysis: %w", err)
+	}
+	if a == nil {
+		return fmt.Errorf("analysis not found")
+	}
+
+	c, err := s.contractRepo.FindContractByID(ctx, a.ContractID)
+	if err != nil {
+		return fmt.Errorf("find contract: %w", err)
+	}
+	if c == nil {
+		return fmt.Errorf("contract not found")
+	}
+
+	member, err := s.userRepo.IsOrgMember(ctx, userID, c.OrganizationID)
+	if err != nil {
+		return fmt.Errorf("check membership: %w", err)
+	}
+	if !member {
+		return fmt.Errorf("access denied")
+	}
+	return nil
 }
 
 // GetEvidenceSet retrieves an evidence set by ID.
-func (s *EvidenceService) GetEvidenceSet(ctx context.Context, id string) (*model.EvidenceSet, error) {
+// userID must be a member of the evidence set's contract organization.
+func (s *EvidenceService) GetEvidenceSet(ctx context.Context, id, userID string) (*model.EvidenceSet, error) {
 	es, err := s.evidenceRepo.FindEvidenceSetByID(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("evidenceService.GetEvidenceSet: %w", err)
 	}
+	if es == nil {
+		return nil, nil
+	}
+
+	if err := s.checkEvidenceSetAccess(ctx, es, userID); err != nil {
+		return nil, fmt.Errorf("evidenceService.GetEvidenceSet: %w", err)
+	}
+
 	return es, nil
 }
 
 // RetrieveEvidence re-triggers the evidence retrieval for an evidence set.
 // The actual retrieval is handled by the AI worker; we publish a queue message.
-func (s *EvidenceService) RetrieveEvidence(ctx context.Context, evidenceSetID string, topK int, filterParams string) error {
+// userID must be a member of the evidence set's contract organization.
+func (s *EvidenceService) RetrieveEvidence(ctx context.Context, evidenceSetID string, topK int, filterParams string, userID string) error {
 	es, err := s.evidenceRepo.FindEvidenceSetByID(ctx, evidenceSetID)
 	if err != nil {
 		return fmt.Errorf("evidenceService.RetrieveEvidence: %w", err)
 	}
 	if es == nil {
 		return fmt.Errorf("evidenceService.RetrieveEvidence: evidence set not found")
+	}
+
+	if err := s.checkEvidenceSetAccess(ctx, es, userID); err != nil {
+		return fmt.Errorf("evidenceService.RetrieveEvidence: %w", err)
 	}
 
 	msg := map[string]interface{}{


### PR DESCRIPTION
## 변경사항
- GetIngestionJob: job → contract를 통해 org 멤버십 확인 (IDOR 수정)
- CreateAnalysis: 분석 생성 전 contract org 멤버십 확인 (IDOR 수정)
- CreateOverride: 오버라이드 생성 전 analysis → contract → org 멤버십 확인 (IDOR 수정)
- GetEvidenceSet: evidence_set → clause_result → analysis → contract 체인으로 org 멤버십 확인 (IDOR 수정)
- RetrieveEvidence: 동일한 org 멤버십 확인 (IDOR 수정)
- EvidenceService에 필요한 repo 의존성 추가 (analysisRepo, contractRepo, userRepo)

## QA 결과
- go build ./... 통과
- go vet ./... 통과
- 인증된 사용자가 다른 org의 ingestion job/evidence set/analysis에 접근 시 403 반환

Closes #63