### PR TITLE
fix(#64): rate limiter TTL 창 리셋 버그 수정

### DIFF
--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -63,12 +63,16 @@ func (c *Client) SetNX(ctx context.Context, key string, value interface{}, ttl t
 	return ok, nil
 }
 
-// Incr atomically increments a counter key and sets its TTL on first creation.
+// Incr atomically increments a counter key and sets its TTL only on first creation.
+// Using ExpireNX ensures the TTL is set once (when the key is new) and not reset
+// on subsequent calls — this implements a true fixed-window rate limit.
 // Returns the new counter value.
 func (c *Client) Incr(ctx context.Context, key string, ttl time.Duration) (int64, error) {
 	pipe := c.rdb.Pipeline()
 	incrCmd := pipe.Incr(ctx, key)
-	pipe.Expire(ctx, key, ttl)
+	// ExpireNX sets the TTL only if the key has no expiry (i.e., it was just created).
+	// This prevents the window from being extended on every request.
+	pipe.ExpireNX(ctx, key, ttl)
 	if _, err := pipe.Exec(ctx); err != nil {
 		return 0, fmt.Errorf("cache.Incr: %w", err)
 	}

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -12,7 +12,7 @@ import (
 
 // RateLimiter returns a middleware that limits requests per IP per endpoint.
 // limit is the maximum number of requests allowed per window.
-// window is the duration of the sliding window.
+// window is the duration of the fixed window (TTL set once on key creation).
 // On Redis failure the middleware fails open (allows the request).
 func RateLimiter(cacheClient *cache.Client, limit int64, window time.Duration) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {


### PR DESCRIPTION
## 변경사항
- cache.Incr()에서 EXPIRE를 ExpireNX로 변경
- ExpireNX는 키에 TTL이 없을 때만 (= 키 생성 시) TTL을 설정
- 기존 EXPIRE는 매 요청마다 TTL을 리셋하여 공격자가 60초 간격으로 계속 10회 요청 가능했음
- 이제 진정한 고정 창(fixed window) 방식으로 동작

## QA 결과
- go build ./... 통과
- go vet ./... 통과

Closes #64