### PR TITLE
fix(#76): audit 고루틴에서 r.Context() 대신 context.Background() 사용

### DIFF
--- a/internal/handler/analysis_handler.go
+++ b/internal/handler/analysis_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"net"
 	"net/http"
@@ -43,8 +44,7 @@ func (h *AnalysisHandler) logAudit(r *http.Request, action string, targetType, t
 		req.ActorID = &userID
 	}
 	go func() {
-		ctx := r.Context()
-		_, _ = h.auditSvc.CreateAuditEvent(ctx, req)
+		_, _ = h.auditSvc.CreateAuditEvent(context.Background(), req)
 	}()
 }
 

--- a/internal/handler/contract_handler.go
+++ b/internal/handler/contract_handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -61,11 +62,10 @@ func (h *ContractHandler) logAudit(r *http.Request, action string, targetType, t
 	if userID != "" {
 		req.ActorID = &userID
 	}
-	// Fire-and-forget: use a background context so the audit write is not
+	// Fire-and-forget: use context.Background() so the audit write is not
 	// cancelled when the HTTP request context is done.
 	go func() {
-		ctx := r.Context()
-		_, _ = h.auditSvc.CreateAuditEvent(ctx, req)
+		_, _ = h.auditSvc.CreateAuditEvent(context.Background(), req)
 	}()
 }
 


### PR DESCRIPTION
## 변경사항

- `internal/handler/contract_handler.go`: `logAudit` 고루틴에서 `r.Context()` → `context.Background()` 수정
- `internal/handler/analysis_handler.go`: 동일 수정

## 문제

HTTP 핸들러가 응답을 반환하면 Go의 `net/http`가 request context를 즉시 취소한다. fire-and-forget 고루틴이 이미 취소된 `r.Context()`로 `CreateAuditEvent`를 호출하면 DB 쿼리가 `context.Canceled` 에러로 실패하여 **audit 이벤트가 무음으로 누락**된다.

주석에 "use a background context so the audit write is not cancelled"라고 명시되어 있었으나 실제 구현이 `r.Context()`를 사용하는 불일치가 있었다.

## QA 결과

- [x] `go build ./...` 통과
- [x] `go vet ./...` 통과

Closes #76