### PR TITLE
fix(#80): X-Request-ID 상관관계 로깅 추가

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -114,6 +114,7 @@ func main() {
 
 	// --- Router ---
 	r := chi.NewRouter()
+	r.Use(chimiddleware.RequestID) // must run before Logger so GetReqID works
 	r.Use(chimiddleware.Recoverer)
 	r.Use(middleware.Logger)
 	r.Use(middleware.CORS(allowedOrigins))

--- a/internal/middleware/logging.go
+++ b/internal/middleware/logging.go
@@ -4,6 +4,8 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
 )
 
 // responseWriter wraps http.ResponseWriter to capture the status code.
@@ -17,10 +19,18 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
-// Logger logs method, path, status code and duration for each request.
+// Logger logs method, path, status code, duration, and request ID for each request.
+// It expects chi's RequestID middleware to run before it so that GetReqID returns a value.
 func Logger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
+		reqID := chimiddleware.GetReqID(r.Context())
+
+		// Echo request ID back to the caller for client-side correlation.
+		if reqID != "" {
+			w.Header().Set("X-Request-ID", reqID)
+		}
+
 		rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
 		next.ServeHTTP(rw, r)
 		slog.Info("http",
@@ -29,6 +39,7 @@ func Logger(next http.Handler) http.Handler {
 			"status", rw.statusCode,
 			"duration_ms", time.Since(start).Milliseconds(),
 			"remote_addr", r.RemoteAddr,
+			"request_id", reqID,
 		)
 	})
 }


### PR DESCRIPTION
## 변경사항
- `main.go`: `chi middleware.RequestID`를 Logger 앞에 등록
- `logging.go`: `GetReqID(ctx)`로 `request_id` 필드를 slog 로그에 추가
- `logging.go`: 응답 헤더 `X-Request-ID` 설정

## QA 결과
- go build ./...: OK
- go vet ./...: OK

Closes #80