### PR TITLE
fix(#82): JWT 클레임에 orgId 포함 및 OrgIDFromContext 헬퍼 추가

### DIFF
--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -13,12 +13,14 @@ type contextKey string
 const (
 	ContextKeyUserID   contextKey = "userID"
 	ContextKeyUserRole contextKey = "userRole"
+	ContextKeyOrgID    contextKey = "orgID"
 )
 
 // Claims holds the JWT payload.
 type Claims struct {
 	UserID string `json:"userId"`
 	Role   string `json:"role"`
+	OrgID  string `json:"orgId"`
 	jwt.RegisteredClaims
 }
 
@@ -53,6 +55,7 @@ func Authenticate(jwtSecret string) func(http.Handler) http.Handler {
 
 			ctx := context.WithValue(r.Context(), ContextKeyUserID, claims.UserID)
 			ctx = context.WithValue(ctx, ContextKeyUserRole, claims.Role)
+			ctx = context.WithValue(ctx, ContextKeyOrgID, claims.OrgID)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
@@ -67,6 +70,13 @@ func UserIDFromContext(ctx context.Context) string {
 // UserRoleFromContext extracts the user role from the request context.
 func UserRoleFromContext(ctx context.Context) string {
 	v, _ := ctx.Value(ContextKeyUserRole).(string)
+	return v
+}
+
+// OrgIDFromContext extracts the organization ID embedded in the JWT from the request context.
+// Returns an empty string for tokens issued before this field was added.
+func OrgIDFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(ContextKeyOrgID).(string)
 	return v
 }
 

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -307,9 +307,21 @@ func (s *AuthService) GetMe(ctx context.Context, userID string) (*GetMeResult, e
 
 func (s *AuthService) issueTokens(ctx context.Context, u *model.User) (*TokenPair, error) {
 	expiresAt := time.Now().Add(accessTokenTTL)
+
+	// Embed orgId so handlers can avoid a DB round-trip for the common case.
+	// The IDOR checks in each handler still verify membership explicitly.
+	var orgID string
+	org, err := s.userRepo.FindOrganizationByUserID(ctx, u.ID)
+	if err != nil {
+		slog.Warn("issueTokens: could not look up org for user", "userId", u.ID, "err", err)
+	} else if org != nil {
+		orgID = org.ID
+	}
+
 	claims := jwt.MapClaims{
 		"userId": u.ID,
 		"role":   u.Role,
+		"orgId":  orgID,
 		"exp":    expiresAt.Unix(),
 		"iat":    time.Now().Unix(),
 	}


### PR DESCRIPTION
## 변경사항
- `auth_service.go`: `issueTokens()`에서 `FindOrganizationByUserID`로 orgId를 조회한 후 JWT 클레임에 포함 (org 없는 경우 빈 문자열, 경고 로그)
- `middleware/auth.go`: `Claims` 구조체에 `OrgID string \`json:"orgId"\`` 추가
- `middleware/auth.go`: `ContextKeyOrgID` 상수 및 `OrgIDFromContext(ctx)` 헬퍼 추가
- 기존 `IsOrgMember()` 호출은 모두 유지 (IDOR 보호는 변경 없음)

## QA 결과
- go build ./...: OK
- go vet ./...: OK

Closes #82