### PR TITLE
fix(#84): add X-Content-Type-Options and X-Frame-Options security headers

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -116,6 +116,7 @@ func main() {
 	r := chi.NewRouter()
 	r.Use(chimiddleware.RequestID) // must run before Logger so GetReqID works
 	r.Use(chimiddleware.Recoverer)
+	r.Use(middleware.SecurityHeaders)
 	r.Use(middleware.Logger)
 	r.Use(middleware.CORS(allowedOrigins))
 

--- a/internal/middleware/logging.go
+++ b/internal/middleware/logging.go
@@ -19,6 +19,18 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
+// SecurityHeaders adds baseline security headers to every response.
+// These are defence-in-depth headers relevant even for a JSON-only API.
+func SecurityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Prevent MIME-type sniffing.
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		// Deny embedding in frames (clickjacking).
+		w.Header().Set("X-Frame-Options", "DENY")
+		next.ServeHTTP(w, r)
+	})
+}
+
 // Logger logs method, path, status code, duration, and request ID for each request.
 // It expects chi's RequestID middleware to run before it so that GetReqID returns a value.
 func Logger(next http.Handler) http.Handler {


### PR DESCRIPTION
## 변경사항
- `SecurityHeaders` middleware 추가 (`internal/middleware/logging.go`)
- chi 라우터에 `r.Use(middleware.SecurityHeaders)` 등록 (`cmd/server/main.go`)
- 모든 응답에 `X-Content-Type-Options: nosniff` 및 `X-Frame-Options: DENY` 헤더 추가

## QA 결과
- `go build ./...` 통과
- `go vet ./...` 통과

Closes #84