### PR TITLE
fix(#85): increase bcrypt cost from DefaultCost (10) to 12

### DIFF
--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -67,7 +67,7 @@ func (s *AuthService) Signup(ctx context.Context, req SignupRequest) (*SignupRes
 		return nil, fmt.Errorf("authService.Signup: email already registered")
 	}
 
-	hash, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+	hash, err := bcrypt.GenerateFromPassword([]byte(req.Password), 12)
 	if err != nil {
 		return nil, fmt.Errorf("authService.Signup: hash password: %w", err)
 	}
@@ -258,7 +258,7 @@ func (s *AuthService) ResetPassword(ctx context.Context, token, newPassword stri
 		return fmt.Errorf("authService.ResetPassword: invalid or expired token")
 	}
 
-	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
+	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), 12)
 	if err != nil {
 		return fmt.Errorf("authService.ResetPassword: hash: %w", err)
 	}


### PR DESCRIPTION
## 변경사항
- `Signup()`의 bcrypt cost: `bcrypt.DefaultCost` (10) → 12
- `ResetPassword()`의 bcrypt cost: `bcrypt.DefaultCost` (10) → 12

## 이유
OWASP 권장 bcrypt cost는 최소 12. DefaultCost(10)는 현재 하드웨어에서 오프라인 브루트포스에 취약.

## QA 결과
- `go build ./...` 통과
- `go vet ./...` 통과

Closes #85