### PR TITLE
feat(#88): POST /auth/resend-verification 이메일 인증 재발송

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -135,6 +135,7 @@ func main() {
 		r.Post("/logout", authHandler.Logout)
 		r.Post("/password/forgot", authHandler.ForgotPassword)
 		r.Post("/password/reset", authHandler.ResetPassword)
+		r.With(signupLimiter).Post("/resend-verification", authHandler.ResendVerification)
 	})
 
 	// Protected routes

--- a/internal/handler/auth_handler.go
+++ b/internal/handler/auth_handler.go
@@ -176,6 +176,21 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 	util.JSON(w, http.StatusOK, map[string]string{"message": "logged out"})
 }
 
+// ResendVerification handles POST /auth/resend-verification
+func (h *AuthHandler) ResendVerification(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Email string `json:"email"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		util.Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	// Always return 200 regardless of account state (security: prevent enumeration).
+	_ = h.authSvc.ResendVerification(r.Context(), req.Email)
+	util.JSON(w, http.StatusOK, map[string]string{"message": "if the email exists and is unverified, a new verification link has been sent"})
+}
+
 // ForgotPassword handles POST /auth/password/forgot
 func (h *AuthHandler) ForgotPassword(w http.ResponseWriter, r *http.Request) {
 	var req struct {

--- a/internal/repository/user_repo.go
+++ b/internal/repository/user_repo.go
@@ -109,6 +109,20 @@ func (r *UserRepo) MarkEmailVerified(ctx context.Context, id string) error {
 	return nil
 }
 
+// SetEmailVerifyToken replaces the current email verification token with a new one.
+func (r *UserRepo) SetEmailVerifyToken(ctx context.Context, id, token string, expires time.Time) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE users
+		SET email_verify_token = $1,
+		    email_verify_expires_at = $2,
+		    updated_at = NOW()
+		WHERE id = $3`, token, expires, id)
+	if err != nil {
+		return fmt.Errorf("userRepo.SetEmailVerifyToken: %w", err)
+	}
+	return nil
+}
+
 // SetPasswordResetToken stores a password reset token.
 func (r *UserRepo) SetPasswordResetToken(ctx context.Context, id, token string, expires time.Time) error {
 	_, err := r.db.ExecContext(ctx, `

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -274,6 +274,31 @@ func (s *AuthService) ResetPassword(ctx context.Context, token, newPassword stri
 	return nil
 }
 
+// ResendVerification issues a new email-verification token and sends it.
+// Always returns nil to prevent account enumeration.
+func (s *AuthService) ResendVerification(ctx context.Context, emailAddr string) error {
+	u, err := s.userRepo.FindByEmail(ctx, emailAddr)
+	if err != nil {
+		return fmt.Errorf("authService.ResendVerification: %w", err)
+	}
+	if u == nil || u.EmailVerified {
+		// Silently succeed — do not reveal whether the address exists or is already verified.
+		return nil
+	}
+
+	verifyToken := generateOpaqueToken()
+	expires := time.Now().Add(verifyTokenTTL)
+	if err := s.userRepo.SetEmailVerifyToken(ctx, u.ID, verifyToken, expires); err != nil {
+		return fmt.Errorf("authService.ResendVerification: %w", err)
+	}
+
+	if err := s.emailClient.SendVerificationEmail(u.Email, verifyToken); err != nil {
+		slog.Warn("authService.ResendVerification: failed to send email",
+			"userId", u.ID, "error", err)
+	}
+	return nil
+}
+
 // GetMeResult holds user details together with the primary organization.
 type GetMeResult struct {
 	User           *model.User


### PR DESCRIPTION
## 변경사항
- `AuthService.ResendVerification`: 미인증 사용자에게 새 인증 토큰 발급 및 메일 발송
- `UserRepo.SetEmailVerifyToken`: 기존 토큰 교체 SQL 추가
- `AuthHandler.ResendVerification`: 항상 200 반환 (계정 존재 여부 노출 방지)
- `POST /auth/resend-verification` 라우트 등록 (rate limit 5회/분 적용)

## QA 결과
- 빌드 성공 (`go build ./...`)
- enumeration 방지: 이메일 없거나 이미 인증된 경우에도 200 반환
- Rate limit: signupLimiter (5회/분) 재사용

Closes #88