### PR TITLE
feat(#97): 프로필/비밀번호/조직/멤버 관리 API

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -92,6 +92,7 @@ func main() {
 	// --- Services ---
 	userRepo := repository.NewUserRepo(db)
 	authSvc := service.NewAuthService(userRepo, cacheClient, emailClient, jwtSecret)
+	orgSvc := service.NewOrgService(userRepo)
 
 	contractRepo := repository.NewContractRepo(db)
 	contractSvc := service.NewContractService(contractRepo, userRepo, queueClient, storageClient)
@@ -107,6 +108,7 @@ func main() {
 
 	// --- Handlers ---
 	authHandler := handler.NewAuthHandler(authSvc)
+	orgHandler := handler.NewOrgHandler(orgSvc, authSvc)
 	contractHandler := handler.NewContractHandler(contractSvc, auditSvc)
 	analysisHandler := handler.NewAnalysisHandler(analysisSvc, auditSvc)
 	evidenceHandler := handler.NewEvidenceHandler(evidenceSvc)
@@ -143,6 +145,16 @@ func main() {
 		r.Use(middleware.Authenticate(jwtSecret))
 
 		r.Get("/users/me", authHandler.GetMe)
+		r.Patch("/users/me", orgHandler.UpdateProfile)
+		r.Patch("/users/me/password", orgHandler.ChangePassword)
+
+		r.Route("/organizations/{orgId}", func(r chi.Router) {
+			r.Get("/", orgHandler.GetOrganization)
+			r.Patch("/", orgHandler.UpdateOrganization)
+			r.Get("/members", orgHandler.ListMembers)
+			r.Post("/members", orgHandler.InviteMember)
+			r.Delete("/members/{userId}", orgHandler.RemoveMember)
+		})
 
 		r.Route("/contracts", func(r chi.Router) {
 			r.Get("/", contractHandler.List)

--- a/internal/handler/org_handler.go
+++ b/internal/handler/org_handler.go
@@ -1,0 +1,193 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/signsafe-io/signsafe-api/internal/middleware"
+	"github.com/signsafe-io/signsafe-api/internal/service"
+	"github.com/signsafe-io/signsafe-api/internal/util"
+)
+
+// OrgHandler handles organization and user-profile HTTP requests.
+type OrgHandler struct {
+	orgSvc  *service.OrgService
+	authSvc *service.AuthService
+}
+
+// NewOrgHandler creates a new OrgHandler.
+func NewOrgHandler(orgSvc *service.OrgService, authSvc *service.AuthService) *OrgHandler {
+	return &OrgHandler{orgSvc: orgSvc, authSvc: authSvc}
+}
+
+// UpdateProfile handles PATCH /users/me
+func (h *OrgHandler) UpdateProfile(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.UserIDFromContext(r.Context())
+	var body struct {
+		FullName string `json:"fullName"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		util.Error(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if body.FullName == "" {
+		util.Error(w, http.StatusBadRequest, "fullName is required")
+		return
+	}
+	u, err := h.authSvc.UpdateProfile(r.Context(), userID, body.FullName)
+	if err != nil {
+		util.Error(w, http.StatusInternalServerError, "failed to update profile")
+		return
+	}
+	util.JSON(w, http.StatusOK, map[string]interface{}{
+		"id":       u.ID,
+		"email":    u.Email,
+		"fullName": u.FullName,
+	})
+}
+
+// ChangePassword handles PATCH /users/me/password
+func (h *OrgHandler) ChangePassword(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.UserIDFromContext(r.Context())
+	var body struct {
+		CurrentPassword string `json:"currentPassword"`
+		NewPassword     string `json:"newPassword"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		util.Error(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if body.CurrentPassword == "" || body.NewPassword == "" {
+		util.Error(w, http.StatusBadRequest, "currentPassword and newPassword are required")
+		return
+	}
+	if err := h.authSvc.ChangePassword(r.Context(), userID, body.CurrentPassword, body.NewPassword); err != nil {
+		msg := err.Error()
+		if strings.Contains(msg, "current password is incorrect") {
+			util.Error(w, http.StatusUnauthorized, "current password is incorrect")
+		} else if strings.Contains(msg, "at least 8") {
+			util.Error(w, http.StatusBadRequest, "new password must be at least 8 characters")
+		} else {
+			util.Error(w, http.StatusInternalServerError, "failed to change password")
+		}
+		return
+	}
+	util.JSON(w, http.StatusOK, map[string]string{"message": "password updated"})
+}
+
+// GetOrganization handles GET /organizations/{orgId}
+func (h *OrgHandler) GetOrganization(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.UserIDFromContext(r.Context())
+	orgID := chi.URLParam(r, "orgId")
+	org, err := h.orgSvc.GetOrganization(r.Context(), userID, orgID)
+	if err != nil {
+		if strings.Contains(err.Error(), "access denied") {
+			util.Error(w, http.StatusForbidden, "access denied")
+			return
+		}
+		util.Error(w, http.StatusInternalServerError, "failed to get organization")
+		return
+	}
+	if org == nil {
+		util.Error(w, http.StatusNotFound, "organization not found")
+		return
+	}
+	util.JSON(w, http.StatusOK, org)
+}
+
+// UpdateOrganization handles PATCH /organizations/{orgId}
+func (h *OrgHandler) UpdateOrganization(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.UserIDFromContext(r.Context())
+	orgID := chi.URLParam(r, "orgId")
+	var body struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		util.Error(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if body.Name == "" {
+		util.Error(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	org, err := h.orgSvc.UpdateOrganization(r.Context(), userID, orgID, body.Name)
+	if err != nil {
+		if strings.Contains(err.Error(), "access denied") {
+			util.Error(w, http.StatusForbidden, "access denied")
+			return
+		}
+		util.Error(w, http.StatusInternalServerError, "failed to update organization")
+		return
+	}
+	util.JSON(w, http.StatusOK, org)
+}
+
+// ListMembers handles GET /organizations/{orgId}/members
+func (h *OrgHandler) ListMembers(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.UserIDFromContext(r.Context())
+	orgID := chi.URLParam(r, "orgId")
+	members, err := h.orgSvc.ListMembers(r.Context(), userID, orgID)
+	if err != nil {
+		if strings.Contains(err.Error(), "access denied") {
+			util.Error(w, http.StatusForbidden, "access denied")
+			return
+		}
+		util.Error(w, http.StatusInternalServerError, "failed to list members")
+		return
+	}
+	util.JSON(w, http.StatusOK, map[string]interface{}{
+		"members": members,
+		"total":   len(members),
+	})
+}
+
+// InviteMember handles POST /organizations/{orgId}/members
+func (h *OrgHandler) InviteMember(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.UserIDFromContext(r.Context())
+	orgID := chi.URLParam(r, "orgId")
+	var body struct {
+		Email string `json:"email"`
+		Role  string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		util.Error(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if body.Email == "" {
+		util.Error(w, http.StatusBadRequest, "email is required")
+		return
+	}
+	if err := h.orgSvc.InviteMember(r.Context(), userID, orgID, body.Email, body.Role); err != nil {
+		msg := err.Error()
+		if strings.Contains(msg, "access denied") {
+			util.Error(w, http.StatusForbidden, "access denied")
+		} else if strings.Contains(msg, "user not found") {
+			util.Error(w, http.StatusNotFound, "user with that email not found")
+		} else {
+			util.Error(w, http.StatusInternalServerError, "failed to invite member")
+		}
+		return
+	}
+	util.JSON(w, http.StatusOK, map[string]string{"message": "member added"})
+}
+
+// RemoveMember handles DELETE /organizations/{orgId}/members/{userId}
+func (h *OrgHandler) RemoveMember(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.UserIDFromContext(r.Context())
+	orgID := chi.URLParam(r, "orgId")
+	targetUserID := chi.URLParam(r, "userId")
+	if err := h.orgSvc.RemoveMember(r.Context(), userID, orgID, targetUserID); err != nil {
+		msg := err.Error()
+		if strings.Contains(msg, "access denied") {
+			util.Error(w, http.StatusForbidden, "access denied")
+		} else if strings.Contains(msg, "cannot remove yourself") {
+			util.Error(w, http.StatusBadRequest, "cannot remove yourself from organization")
+		} else {
+			util.Error(w, http.StatusInternalServerError, "failed to remove member")
+		}
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/repository/user_repo.go
+++ b/internal/repository/user_repo.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"github.com/signsafe-io/signsafe-api/internal/model"
+	"github.com/signsafe-io/signsafe-api/internal/util"
 )
 
 // UserRepo handles DB operations for users and tokens.
@@ -310,4 +311,100 @@ func (r *UserRepo) FindOrganizationByUserID(ctx context.Context, userID string) 
 		return nil, fmt.Errorf("userRepo.FindOrganizationByUserID: %w", err)
 	}
 	return &org, nil
+}
+
+// FindOrganizationByID returns an organization by ID.
+func (r *UserRepo) FindOrganizationByID(ctx context.Context, orgID string) (*model.Organization, error) {
+	var org model.Organization
+	err := r.db.GetContext(ctx, &org, `SELECT * FROM organizations WHERE id = $1`, orgID)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("userRepo.FindOrganizationByID: %w", err)
+	}
+	return &org, nil
+}
+
+// UpdateOrganizationName updates the name of an organization.
+// Returns nil, nil if the organization does not exist.
+func (r *UserRepo) UpdateOrganizationName(ctx context.Context, orgID, name string) (*model.Organization, error) {
+	var org model.Organization
+	err := r.db.GetContext(ctx, &org, `
+		UPDATE organizations SET name = $1, updated_at = NOW()
+		WHERE id = $2
+		RETURNING *`, name, orgID)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("userRepo.UpdateOrganizationName: %w", err)
+	}
+	return &org, nil
+}
+
+// UpdateFullName updates a user's display name.
+// Returns nil, nil if the user does not exist.
+func (r *UserRepo) UpdateFullName(ctx context.Context, userID, fullName string) (*model.User, error) {
+	var u model.User
+	err := r.db.GetContext(ctx, &u, `
+		UPDATE users SET full_name = $1, updated_at = NOW()
+		WHERE id = $2
+		RETURNING *`, fullName, userID)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("userRepo.UpdateFullName: %w", err)
+	}
+	return &u, nil
+}
+
+// OrgMember holds member info returned by ListOrgMembers.
+type OrgMember struct {
+	UserID   string    `db:"user_id"`
+	Email    string    `db:"email"`
+	FullName string    `db:"full_name"`
+	Role     string    `db:"role"`
+	JoinedAt time.Time `db:"joined_at"`
+}
+
+// ListOrgMembers returns all members of an organization.
+func (r *UserRepo) ListOrgMembers(ctx context.Context, orgID string) ([]OrgMember, error) {
+	var members []OrgMember
+	err := r.db.SelectContext(ctx, &members, `
+		SELECT uo.user_id, u.email, u.full_name, uo.role, uo.joined_at
+		FROM user_organizations uo
+		JOIN users u ON u.id = uo.user_id
+		WHERE uo.organization_id = $1
+		ORDER BY uo.joined_at ASC`, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("userRepo.ListOrgMembers: %w", err)
+	}
+	return members, nil
+}
+
+// AddOrgMember adds a user to an organization with the given role.
+func (r *UserRepo) AddOrgMember(ctx context.Context, userID, orgID, role string) error {
+	id := util.NewID()
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO user_organizations (id, user_id, organization_id, role, permissions, joined_at)
+		VALUES ($1, $2, $3, $4, '[]', NOW())
+		ON CONFLICT (user_id, organization_id) DO NOTHING`,
+		id, userID, orgID, role)
+	if err != nil {
+		return fmt.Errorf("userRepo.AddOrgMember: %w", err)
+	}
+	return nil
+}
+
+// RemoveOrgMember removes a user from an organization.
+func (r *UserRepo) RemoveOrgMember(ctx context.Context, userID, orgID string) error {
+	_, err := r.db.ExecContext(ctx, `
+		DELETE FROM user_organizations
+		WHERE user_id = $1 AND organization_id = $2`, userID, orgID)
+	if err != nil {
+		return fmt.Errorf("userRepo.RemoveOrgMember: %w", err)
+	}
+	return nil
 }

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -412,3 +412,47 @@ func hashToken(raw string) string {
 	h := sha256.Sum256([]byte(raw))
 	return hex.EncodeToString(h[:])
 }
+
+// UpdateProfile updates the display name of the authenticated user.
+func (s *AuthService) UpdateProfile(ctx context.Context, userID, fullName string) (*model.User, error) {
+	if fullName == "" {
+		return nil, fmt.Errorf("authService.UpdateProfile: fullName cannot be empty")
+	}
+	u, err := s.userRepo.UpdateFullName(ctx, userID, fullName)
+	if err != nil {
+		return nil, fmt.Errorf("authService.UpdateProfile: %w", err)
+	}
+	if u == nil {
+		return nil, fmt.Errorf("authService.UpdateProfile: user not found")
+	}
+	return u, nil
+}
+
+// ChangePassword verifies the current password and sets a new one.
+func (s *AuthService) ChangePassword(ctx context.Context, userID, currentPassword, newPassword string) error {
+	if len(newPassword) < 8 {
+		return fmt.Errorf("authService.ChangePassword: new password must be at least 8 characters")
+	}
+	u, err := s.userRepo.FindByID(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("authService.ChangePassword: %w", err)
+	}
+	if u == nil {
+		return fmt.Errorf("authService.ChangePassword: user not found")
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(u.PasswordHash), []byte(currentPassword)); err != nil {
+		return fmt.Errorf("authService.ChangePassword: current password is incorrect")
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), 12)
+	if err != nil {
+		return fmt.Errorf("authService.ChangePassword: hash: %w", err)
+	}
+	if err := s.userRepo.UpdatePassword(ctx, userID, string(hash)); err != nil {
+		return fmt.Errorf("authService.ChangePassword: %w", err)
+	}
+	// Revoke all existing sessions so stolen tokens can't be reused.
+	if err := s.userRepo.RevokeAllRefreshTokens(ctx, userID); err != nil {
+		slog.Warn("authService.ChangePassword: failed to revoke refresh tokens", "userId", userID, "error", err)
+	}
+	return nil
+}

--- a/internal/service/org_service.go
+++ b/internal/service/org_service.go
@@ -1,0 +1,131 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/signsafe-io/signsafe-api/internal/model"
+	"github.com/signsafe-io/signsafe-api/internal/repository"
+)
+
+// OrgService handles organization management operations.
+type OrgService struct {
+	userRepo *repository.UserRepo
+}
+
+// NewOrgService creates a new OrgService.
+func NewOrgService(userRepo *repository.UserRepo) *OrgService {
+	return &OrgService{userRepo: userRepo}
+}
+
+// GetOrganization returns an organization if the requesting user is a member.
+func (s *OrgService) GetOrganization(ctx context.Context, userID, orgID string) (*model.Organization, error) {
+	member, err := s.userRepo.IsOrgMember(ctx, userID, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("orgService.GetOrganization: %w", err)
+	}
+	if !member {
+		return nil, fmt.Errorf("orgService.GetOrganization: access denied")
+	}
+	org, err := s.userRepo.FindOrganizationByID(ctx, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("orgService.GetOrganization: %w", err)
+	}
+	return org, nil
+}
+
+// UpdateOrganization updates the org name if the requesting user is a member.
+func (s *OrgService) UpdateOrganization(ctx context.Context, userID, orgID, name string) (*model.Organization, error) {
+	if name == "" {
+		return nil, fmt.Errorf("orgService.UpdateOrganization: name cannot be empty")
+	}
+	member, err := s.userRepo.IsOrgMember(ctx, userID, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("orgService.UpdateOrganization: %w", err)
+	}
+	if !member {
+		return nil, fmt.Errorf("orgService.UpdateOrganization: access denied")
+	}
+	org, err := s.userRepo.UpdateOrganizationName(ctx, orgID, name)
+	if err != nil {
+		return nil, fmt.Errorf("orgService.UpdateOrganization: %w", err)
+	}
+	if org == nil {
+		return nil, fmt.Errorf("orgService.UpdateOrganization: organization not found")
+	}
+	return org, nil
+}
+
+// MemberInfo is the public view of a member.
+type MemberInfo struct {
+	UserID   string `json:"userId"`
+	Email    string `json:"email"`
+	FullName string `json:"fullName"`
+	Role     string `json:"role"`
+	JoinedAt string `json:"joinedAt"`
+}
+
+// ListMembers returns members of an org if the requesting user is a member.
+func (s *OrgService) ListMembers(ctx context.Context, userID, orgID string) ([]MemberInfo, error) {
+	member, err := s.userRepo.IsOrgMember(ctx, userID, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("orgService.ListMembers: %w", err)
+	}
+	if !member {
+		return nil, fmt.Errorf("orgService.ListMembers: access denied")
+	}
+	rows, err := s.userRepo.ListOrgMembers(ctx, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("orgService.ListMembers: %w", err)
+	}
+	out := make([]MemberInfo, len(rows))
+	for i, m := range rows {
+		out[i] = MemberInfo{
+			UserID:   m.UserID,
+			Email:    m.Email,
+			FullName: m.FullName,
+			Role:     m.Role,
+			JoinedAt: m.JoinedAt.Format("2006-01-02T15:04:05Z"),
+		}
+	}
+	return out, nil
+}
+
+// InviteMember adds a user (looked up by email) to an org.
+// The inviting user must already be a member.
+func (s *OrgService) InviteMember(ctx context.Context, userID, orgID, email, role string) error {
+	member, err := s.userRepo.IsOrgMember(ctx, userID, orgID)
+	if err != nil {
+		return fmt.Errorf("orgService.InviteMember: %w", err)
+	}
+	if !member {
+		return fmt.Errorf("orgService.InviteMember: access denied")
+	}
+	if role == "" {
+		role = "member"
+	}
+	target, err := s.userRepo.FindByEmail(ctx, email)
+	if err != nil {
+		return fmt.Errorf("orgService.InviteMember: %w", err)
+	}
+	if target == nil {
+		return fmt.Errorf("orgService.InviteMember: user not found")
+	}
+	return s.userRepo.AddOrgMember(ctx, target.ID, orgID, role)
+}
+
+// RemoveMember removes a member from the org.
+// The requesting user must be a member; they cannot remove themselves.
+func (s *OrgService) RemoveMember(ctx context.Context, userID, orgID, targetUserID string) error {
+	if userID == targetUserID {
+		return fmt.Errorf("orgService.RemoveMember: cannot remove yourself")
+	}
+	member, err := s.userRepo.IsOrgMember(ctx, userID, orgID)
+	if err != nil {
+		return fmt.Errorf("orgService.RemoveMember: %w", err)
+	}
+	if !member {
+		return fmt.Errorf("orgService.RemoveMember: access denied")
+	}
+	return s.userRepo.RemoveOrgMember(ctx, targetUserID, orgID)
+}


### PR DESCRIPTION
## 변경사항

- **PATCH /users/me** — 프로필 이름 변경
- **PATCH /users/me/password** — 비밀번호 변경 (성공 시 모든 refresh token 무효화)
- **GET /organizations/:id** — 조직 정보 조회
- **PATCH /organizations/:id** — 조직 이름 변경
- **GET /organizations/:id/members** — 멤버 목록
- **POST /organizations/:id/members** — 이메일로 기존 사용자 추가
- **DELETE /organizations/:id/members/:userId** — 멤버 제거 (본인 제거 불가)

## QA 결과

- `go build ./...` / `go vet ./...` 통과
- SQL Injection 없음 (파라미터화 쿼리)
- IsOrgMember 권한 체크 전 엔드포인트 적용
- sql.ErrNoRows nil 처리, bcrypt cost=12
- 비밀번호 변경 후 refresh token 전체 무효화

Closes #97