### PR TITLE
feat(#99): 미가입자 이메일 초대, 멤버 역할 변경, 조직 admin 권한 체크

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -92,7 +92,7 @@ func main() {
 	// --- Services ---
 	userRepo := repository.NewUserRepo(db)
 	authSvc := service.NewAuthService(userRepo, cacheClient, emailClient, jwtSecret)
-	orgSvc := service.NewOrgService(userRepo)
+	orgSvc := service.NewOrgService(userRepo, emailClient, appBaseURL)
 
 	contractRepo := repository.NewContractRepo(db)
 	contractSvc := service.NewContractService(contractRepo, userRepo, queueClient, storageClient)
@@ -107,7 +107,7 @@ func main() {
 	auditSvc := service.NewAuditService(auditRepo)
 
 	// --- Handlers ---
-	authHandler := handler.NewAuthHandler(authSvc)
+	authHandler := handler.NewAuthHandler(authSvc, orgSvc)
 	orgHandler := handler.NewOrgHandler(orgSvc, authSvc)
 	contractHandler := handler.NewContractHandler(contractSvc, auditSvc)
 	analysisHandler := handler.NewAnalysisHandler(analysisSvc, auditSvc)
@@ -153,6 +153,7 @@ func main() {
 			r.Patch("/", orgHandler.UpdateOrganization)
 			r.Get("/members", orgHandler.ListMembers)
 			r.Post("/members", orgHandler.InviteMember)
+			r.Patch("/members/{userId}", orgHandler.UpdateMemberRole)
 			r.Delete("/members/{userId}", orgHandler.RemoveMember)
 		})
 

--- a/internal/email/email.go
+++ b/internal/email/email.go
@@ -227,9 +227,61 @@ func buildHTMLMessage(from, to, subject, body string) string {
 	return sb.String()
 }
 
-func truncate(s string, n int) string {
-	if len(s) <= n {
-		return s
-	}
-	return s[:n] + "..."
+// SendInvitationEmail sends an invitation email to a new or existing user.
+func (c *Client) SendInvitationEmail(to, orgName, inviterName, signupURL string) error {
+	subject := fmt.Sprintf("[SignSafe] %s 조직에 초대되었습니다", orgName)
+	body := fmt.Sprintf(`<!DOCTYPE html>
+<html lang="ko">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="margin:0;padding:0;background:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
+  <table width="100%%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:40px 0;">
+    <tr><td align="center">
+      <table width="520" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+        <tr>
+          <td style="background:#18181b;padding:32px 40px;">
+            <p style="margin:0;font-size:20px;font-weight:700;color:#ffffff;letter-spacing:-0.3px;">SignSafe</p>
+            <p style="margin:4px 0 0;font-size:12px;color:#a1a1aa;">계약서 리스크 분석 플랫폼</p>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:40px;">
+            <p style="margin:0 0 8px;font-size:22px;font-weight:600;color:#18181b;">조직 초대</p>
+            <p style="margin:0 0 24px;font-size:14px;color:#71717a;line-height:1.6;">
+              <strong style="color:#18181b;">%s</strong>님이 <strong style="color:#18181b;">%s</strong> 조직에 초대했습니다.<br>
+              아래 버튼을 클릭하여 SignSafe에 참여하세요.
+            </p>
+            <table cellpadding="0" cellspacing="0" style="margin:0 0 32px;">
+              <tr>
+                <td style="background:#18181b;border-radius:8px;">
+                  <a href="%s" style="display:inline-block;padding:14px 32px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;letter-spacing:-0.1px;">초대 수락하기</a>
+                </td>
+              </tr>
+            </table>
+            <table width="100%%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;border-radius:8px;padding:16px;">
+              <tr>
+                <td style="font-size:12px;color:#71717a;line-height:1.7;">
+                  • 이 초대 링크는 <strong style="color:#52525b;">7일</strong> 동안 유효합니다.<br>
+                  • 이미 계정이 있는 경우 로그인 후 자동으로 조직에 합류됩니다.<br>
+                  • 버튼이 작동하지 않으면 아래 링크를 복사해주세요.<br>
+                  <span style="color:#3f3f46;word-break:break-all;">%s</span>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:20px 40px;border-top:1px solid #f4f4f5;">
+            <p style="margin:0;font-size:12px;color:#a1a1aa;">
+              본인이 요청하지 않으셨다면 이 이메일을 무시하셔도 됩니다.<br>
+              © 2026 SignSafe. All rights reserved.
+            </p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`, inviterName, orgName, signupURL, signupURL)
+
+	return c.sendHTML(to, subject, body)
 }

--- a/internal/handler/auth_handler.go
+++ b/internal/handler/auth_handler.go
@@ -13,11 +13,12 @@ import (
 // AuthHandler handles auth-related HTTP requests.
 type AuthHandler struct {
 	authSvc *service.AuthService
+	orgSvc  *service.OrgService
 }
 
 // NewAuthHandler creates a new AuthHandler.
-func NewAuthHandler(authSvc *service.AuthService) *AuthHandler {
-	return &AuthHandler{authSvc: authSvc}
+func NewAuthHandler(authSvc *service.AuthService, orgSvc *service.OrgService) *AuthHandler {
+	return &AuthHandler{authSvc: authSvc, orgSvc: orgSvc}
 }
 
 // Signup handles POST /auth/signup
@@ -53,6 +54,9 @@ func (h *AuthHandler) Signup(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+
+	// Accept any pending org invitations for this email.
+	h.orgSvc.AcceptPendingInvitations(r.Context(), result.UserID, req.Email)
 
 	util.JSON(w, http.StatusCreated, map[string]interface{}{
 		"userId":         result.UserID,
@@ -249,15 +253,16 @@ func (h *AuthHandler) GetMe(w http.ResponseWriter, r *http.Request) {
 
 	u := result.User
 	util.JSON(w, http.StatusOK, map[string]interface{}{
-		"id":             u.ID,
-		"email":          u.Email,
-		"fullName":       u.FullName,
-		"role":           u.Role,
-		"emailVerified":  u.EmailVerified,
-		"mfaEnabled":     u.MFAEnabled,
-		"createdAt":      u.CreatedAt,
-		"permissions":    defaultPermissions(u.Role),
-		"organizationId": result.OrganizationID,
+		"id":               u.ID,
+		"email":            u.Email,
+		"fullName":         u.FullName,
+		"role":             u.Role,
+		"emailVerified":    u.EmailVerified,
+		"mfaEnabled":       u.MFAEnabled,
+		"createdAt":        u.CreatedAt,
+		"permissions":      defaultPermissions(u.Role),
+		"organizationId":   result.OrganizationID,
+		"organizationName": result.OrganizationName,
 	})
 }
 

--- a/internal/handler/org_handler.go
+++ b/internal/handler/org_handler.go
@@ -163,14 +163,44 @@ func (h *OrgHandler) InviteMember(w http.ResponseWriter, r *http.Request) {
 		msg := err.Error()
 		if strings.Contains(msg, "access denied") {
 			util.Error(w, http.StatusForbidden, "access denied")
-		} else if strings.Contains(msg, "user not found") {
-			util.Error(w, http.StatusNotFound, "user with that email not found")
+		} else if strings.Contains(msg, "invalid role") {
+			util.Error(w, http.StatusBadRequest, "invalid role")
 		} else {
 			util.Error(w, http.StatusInternalServerError, "failed to invite member")
 		}
 		return
 	}
 	util.JSON(w, http.StatusOK, map[string]string{"message": "member added"})
+}
+
+// UpdateMemberRole handles PATCH /organizations/{orgId}/members/{userId}
+func (h *OrgHandler) UpdateMemberRole(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.UserIDFromContext(r.Context())
+	orgID := chi.URLParam(r, "orgId")
+	targetUserID := chi.URLParam(r, "userId")
+	var body struct {
+		Role string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		util.Error(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if body.Role == "" {
+		util.Error(w, http.StatusBadRequest, "role is required")
+		return
+	}
+	if err := h.orgSvc.UpdateMemberRole(r.Context(), userID, orgID, targetUserID, body.Role); err != nil {
+		msg := err.Error()
+		if strings.Contains(msg, "access denied") {
+			util.Error(w, http.StatusForbidden, "access denied")
+		} else if strings.Contains(msg, "invalid role") {
+			util.Error(w, http.StatusBadRequest, "invalid role")
+		} else {
+			util.Error(w, http.StatusInternalServerError, "failed to update member role")
+		}
+		return
+	}
+	util.JSON(w, http.StatusOK, map[string]string{"message": "role updated"})
 }
 
 // RemoveMember handles DELETE /organizations/{orgId}/members/{userId}

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -37,6 +37,17 @@ type UserOrganization struct {
 	JoinedAt       time.Time `db:"joined_at" json:"joinedAt"`
 }
 
+type PendingInvitation struct {
+	ID             string    `db:"id"`
+	OrganizationID string    `db:"organization_id"`
+	InvitedBy      string    `db:"invited_by"`
+	Email          string    `db:"email"`
+	Role           string    `db:"role"`
+	Token          string    `db:"token"`
+	ExpiresAt      time.Time `db:"expires_at"`
+	CreatedAt      time.Time `db:"created_at"`
+}
+
 type RefreshToken struct {
 	ID        string    `db:"id"`
 	UserID    string    `db:"user_id"`

--- a/internal/repository/user_repo.go
+++ b/internal/repository/user_repo.go
@@ -294,6 +294,23 @@ func (r *UserRepo) IsOrgMember(ctx context.Context, userID, orgID string) (bool,
 	return count > 0, nil
 }
 
+// GetMemberRole returns the role of a user in an org, or "" if not a member.
+func (r *UserRepo) GetMemberRole(ctx context.Context, userID, orgID string) (string, error) {
+	var role string
+	err := r.db.GetContext(ctx, &role, `
+		SELECT role
+		FROM user_organizations
+		WHERE user_id = $1 AND organization_id = $2`,
+		userID, orgID)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("userRepo.GetMemberRole: %w", err)
+	}
+	return role, nil
+}
+
 // FindOrganizationByUserID returns the first organization a user belongs to.
 func (r *UserRepo) FindOrganizationByUserID(ctx context.Context, userID string) (*model.Organization, error) {
 	var org model.Organization
@@ -405,6 +422,70 @@ func (r *UserRepo) RemoveOrgMember(ctx context.Context, userID, orgID string) er
 		WHERE user_id = $1 AND organization_id = $2`, userID, orgID)
 	if err != nil {
 		return fmt.Errorf("userRepo.RemoveOrgMember: %w", err)
+	}
+	return nil
+}
+
+// UpdateMemberRole changes the role of a member in an organization.
+func (r *UserRepo) UpdateMemberRole(ctx context.Context, userID, orgID, role string) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE user_organizations SET role = $1
+		WHERE user_id = $2 AND organization_id = $3`, role, userID, orgID)
+	if err != nil {
+		return fmt.Errorf("userRepo.UpdateMemberRole: %w", err)
+	}
+	return nil
+}
+
+// CreateInvitation stores a pending invitation.
+func (r *UserRepo) CreateInvitation(ctx context.Context, inv *model.PendingInvitation) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO pending_invitations
+		    (id, organization_id, invited_by, email, role, token, expires_at, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
+		ON CONFLICT (organization_id, email)
+		DO UPDATE SET token = EXCLUDED.token,
+		              role = EXCLUDED.role,
+		              expires_at = EXCLUDED.expires_at`,
+		inv.ID, inv.OrganizationID, inv.InvitedBy, inv.Email, inv.Role, inv.Token, inv.ExpiresAt)
+	if err != nil {
+		return fmt.Errorf("userRepo.CreateInvitation: %w", err)
+	}
+	return nil
+}
+
+// FindInvitationByToken retrieves a non-expired invitation by token.
+func (r *UserRepo) FindInvitationByToken(ctx context.Context, token string) (*model.PendingInvitation, error) {
+	var inv model.PendingInvitation
+	err := r.db.GetContext(ctx, &inv, `
+		SELECT * FROM pending_invitations
+		WHERE token = $1 AND expires_at > NOW()`, token)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("userRepo.FindInvitationByToken: %w", err)
+	}
+	return &inv, nil
+}
+
+// FindInvitationsByEmail retrieves all pending invitations for an email.
+func (r *UserRepo) FindInvitationsByEmail(ctx context.Context, email string) ([]model.PendingInvitation, error) {
+	var invs []model.PendingInvitation
+	err := r.db.SelectContext(ctx, &invs, `
+		SELECT * FROM pending_invitations
+		WHERE email = $1 AND expires_at > NOW()`, email)
+	if err != nil {
+		return nil, fmt.Errorf("userRepo.FindInvitationsByEmail: %w", err)
+	}
+	return invs, nil
+}
+
+// DeleteInvitation removes a pending invitation by ID.
+func (r *UserRepo) DeleteInvitation(ctx context.Context, id string) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM pending_invitations WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("userRepo.DeleteInvitation: %w", err)
 	}
 	return nil
 }

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -301,11 +301,12 @@ func (s *AuthService) ResendVerification(ctx context.Context, emailAddr string) 
 
 // GetMeResult holds user details together with the primary organization.
 type GetMeResult struct {
-	User           *model.User
-	OrganizationID string
+	User             *model.User
+	OrganizationID   string
+	OrganizationName string
 }
 
-// GetMe returns the full user details with their primary organization ID.
+// GetMe returns the full user details with their primary organization ID and name.
 func (s *AuthService) GetMe(ctx context.Context, userID string) (*GetMeResult, error) {
 	u, err := s.userRepo.FindByID(ctx, userID)
 	if err != nil {
@@ -320,12 +321,13 @@ func (s *AuthService) GetMe(ctx context.Context, userID string) (*GetMeResult, e
 		return nil, fmt.Errorf("authService.GetMe: find org: %w", err)
 	}
 
-	orgID := ""
+	orgID, orgName := "", ""
 	if org != nil {
 		orgID = org.ID
+		orgName = org.Name
 	}
 
-	return &GetMeResult{User: u, OrganizationID: orgID}, nil
+	return &GetMeResult{User: u, OrganizationID: orgID, OrganizationName: orgName}, nil
 }
 
 // --- internal helpers ---

--- a/internal/service/org_service.go
+++ b/internal/service/org_service.go
@@ -3,19 +3,26 @@ package service
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/signsafe-io/signsafe-api/internal/email"
 	"github.com/signsafe-io/signsafe-api/internal/model"
 	"github.com/signsafe-io/signsafe-api/internal/repository"
+	"github.com/signsafe-io/signsafe-api/internal/util"
 )
+
+const invitationTTL = 7 * 24 * time.Hour
 
 // OrgService handles organization management operations.
 type OrgService struct {
-	userRepo *repository.UserRepo
+	userRepo    *repository.UserRepo
+	emailClient *email.Client
+	appURL      string
 }
 
 // NewOrgService creates a new OrgService.
-func NewOrgService(userRepo *repository.UserRepo) *OrgService {
-	return &OrgService{userRepo: userRepo}
+func NewOrgService(userRepo *repository.UserRepo, emailClient *email.Client, appURL string) *OrgService {
+	return &OrgService{userRepo: userRepo, emailClient: emailClient, appURL: appURL}
 }
 
 // GetOrganization returns an organization if the requesting user is a member.
@@ -34,16 +41,16 @@ func (s *OrgService) GetOrganization(ctx context.Context, userID, orgID string) 
 	return org, nil
 }
 
-// UpdateOrganization updates the org name if the requesting user is a member.
+// UpdateOrganization updates the org name if the requesting user is an admin.
 func (s *OrgService) UpdateOrganization(ctx context.Context, userID, orgID, name string) (*model.Organization, error) {
 	if name == "" {
 		return nil, fmt.Errorf("orgService.UpdateOrganization: name cannot be empty")
 	}
-	member, err := s.userRepo.IsOrgMember(ctx, userID, orgID)
+	role, err := s.userRepo.GetMemberRole(ctx, userID, orgID)
 	if err != nil {
 		return nil, fmt.Errorf("orgService.UpdateOrganization: %w", err)
 	}
-	if !member {
+	if role != "admin" {
 		return nil, fmt.Errorf("orgService.UpdateOrganization: access denied")
 	}
 	org, err := s.userRepo.UpdateOrganizationName(ctx, orgID, name)
@@ -91,41 +98,108 @@ func (s *OrgService) ListMembers(ctx context.Context, userID, orgID string) ([]M
 	return out, nil
 }
 
-// InviteMember adds a user (looked up by email) to an org.
-// The inviting user must already be a member.
-func (s *OrgService) InviteMember(ctx context.Context, userID, orgID, email, role string) error {
-	member, err := s.userRepo.IsOrgMember(ctx, userID, orgID)
+// InviteMember adds or invites a user to an org.
+// If the user already has an account, they are added immediately.
+// If not, an invitation email is sent and the invite is stored pending signup.
+func (s *OrgService) InviteMember(ctx context.Context, userID, orgID, inviteeEmail, role string) error {
+	requesterRole, err := s.userRepo.GetMemberRole(ctx, userID, orgID)
 	if err != nil {
 		return fmt.Errorf("orgService.InviteMember: %w", err)
 	}
-	if !member {
+	if requesterRole != "admin" {
 		return fmt.Errorf("orgService.InviteMember: access denied")
 	}
 	if role == "" {
 		role = "member"
 	}
-	target, err := s.userRepo.FindByEmail(ctx, email)
+	validRoles := map[string]bool{"admin": true, "member": true, "reviewer": true}
+	if !validRoles[role] {
+		return fmt.Errorf("orgService.InviteMember: invalid role %q", role)
+	}
+
+	// Check if this user already exists.
+	target, err := s.userRepo.FindByEmail(ctx, inviteeEmail)
 	if err != nil {
 		return fmt.Errorf("orgService.InviteMember: %w", err)
 	}
-	if target == nil {
-		return fmt.Errorf("orgService.InviteMember: user not found")
+	if target != nil {
+		// Already a SignSafe user — add directly.
+		return s.userRepo.AddOrgMember(ctx, target.ID, orgID, role)
 	}
-	return s.userRepo.AddOrgMember(ctx, target.ID, orgID, role)
+
+	// Not yet a user — create a pending invitation and send email.
+	inviter, err := s.userRepo.FindByID(ctx, userID)
+	if err != nil || inviter == nil {
+		return fmt.Errorf("orgService.InviteMember: inviter not found")
+	}
+	org, err := s.userRepo.FindOrganizationByID(ctx, orgID)
+	if err != nil || org == nil {
+		return fmt.Errorf("orgService.InviteMember: org not found")
+	}
+
+	token := generateOpaqueToken()
+	inv := &model.PendingInvitation{
+		ID:             util.NewID(),
+		OrganizationID: orgID,
+		InvitedBy:      userID,
+		Email:          inviteeEmail,
+		Role:           role,
+		Token:          token,
+		ExpiresAt:      time.Now().Add(invitationTTL),
+	}
+	if err := s.userRepo.CreateInvitation(ctx, inv); err != nil {
+		return fmt.Errorf("orgService.InviteMember: %w", err)
+	}
+
+	signupURL := fmt.Sprintf("%s/signup?invite=%s", s.appURL, token)
+	if err := s.emailClient.SendInvitationEmail(inviteeEmail, org.Name, inviter.FullName, signupURL); err != nil {
+		// Non-fatal: invitation is stored; email delivery failure shouldn't block the operation.
+		_ = err
+	}
+	return nil
+}
+
+// AcceptInvitation adds the newly signed-up user to any pending invitations.
+// Called after a successful signup.
+func (s *OrgService) AcceptPendingInvitations(ctx context.Context, userID, email string) {
+	invs, err := s.userRepo.FindInvitationsByEmail(ctx, email)
+	if err != nil || len(invs) == 0 {
+		return
+	}
+	for _, inv := range invs {
+		if err := s.userRepo.AddOrgMember(ctx, userID, inv.OrganizationID, inv.Role); err == nil {
+			_ = s.userRepo.DeleteInvitation(ctx, inv.ID)
+		}
+	}
 }
 
 // RemoveMember removes a member from the org.
-// The requesting user must be a member; they cannot remove themselves.
 func (s *OrgService) RemoveMember(ctx context.Context, userID, orgID, targetUserID string) error {
 	if userID == targetUserID {
 		return fmt.Errorf("orgService.RemoveMember: cannot remove yourself")
 	}
-	member, err := s.userRepo.IsOrgMember(ctx, userID, orgID)
+	role, err := s.userRepo.GetMemberRole(ctx, userID, orgID)
 	if err != nil {
 		return fmt.Errorf("orgService.RemoveMember: %w", err)
 	}
-	if !member {
+	if role != "admin" {
 		return fmt.Errorf("orgService.RemoveMember: access denied")
 	}
 	return s.userRepo.RemoveOrgMember(ctx, targetUserID, orgID)
+}
+
+// UpdateMemberRole changes the role of a member in the org.
+func (s *OrgService) UpdateMemberRole(ctx context.Context, userID, orgID, targetUserID, role string) error {
+	validRoles := map[string]bool{"admin": true, "member": true, "reviewer": true}
+	if !validRoles[role] {
+		return fmt.Errorf("orgService.UpdateMemberRole: invalid role %q", role)
+	}
+	requesterRole, err := s.userRepo.GetMemberRole(ctx, userID, orgID)
+	if err != nil {
+		return fmt.Errorf("orgService.UpdateMemberRole: %w", err)
+	}
+	if requesterRole != "admin" {
+		return fmt.Errorf("orgService.UpdateMemberRole: access denied")
+	}
+	return s.userRepo.UpdateMemberRole(ctx, targetUserID, orgID, role)
 }

--- a/migrations/000005_pending_invitations.down.sql
+++ b/migrations/000005_pending_invitations.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS pending_invitations;

--- a/migrations/000005_pending_invitations.up.sql
+++ b/migrations/000005_pending_invitations.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE pending_invitations (
+    id              VARCHAR(26)  PRIMARY KEY,
+    organization_id VARCHAR(26)  NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    invited_by      VARCHAR(26)  NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    email           VARCHAR(255) NOT NULL,
+    role            VARCHAR(50)  NOT NULL DEFAULT 'member',
+    token           VARCHAR(64)  NOT NULL UNIQUE,
+    expires_at      TIMESTAMPTZ  NOT NULL,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    UNIQUE (organization_id, email)
+);


### PR DESCRIPTION
## 변경사항

- `pending_invitations` 테이블 추가 (마이그레이션 000005)
- `InviteMember`: 기존 유저는 즉시 추가, 신규 유저는 초대 이메일 발송 (7일 TTL)
- `AcceptPendingInvitations`: 회원가입 완료 시 pending 초대 자동 처리
- `UpdateMemberRole` 핸들러 및 `PATCH /organizations/:id/members/:userId` 라우트 추가
- `GetMe` 응답에 `organizationName` 필드 추가
- `UpdateOrganization`, `InviteMember`, `RemoveMember`, `UpdateMemberRole`: `IsOrgMember` → admin 전용(`GetMemberRole`) 으로 강화
- `user_repo.go`: `GetMemberRole` 메서드 추가
- `email.go`: `SendInvitationEmail` 추가, `truncate` dead code 제거

## QA 결과

- [x] `go build ./...` 통과
- [x] `go vet ./...` 통과
- [x] SQL Injection 없음 (파라미터화 쿼리)
- [x] 에러 처리 누락 없음
- [x] admin 권한 체크 강화
- [x] AcceptPendingInvitations 데이터 유실 버그 수정

Closes #99