### PR TITLE
feat(#101): 조직 생성 및 내 조직 목록 API 추가

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -67,6 +67,24 @@
 
 ---
 
+## 2026-03-30: 조직 생성 및 내 조직 목록 API 추가
+
+**결정**:
+- `GET /users/me/organizations`: 인증된 사용자가 속한 모든 조직과 각각의 role을 배열로 반환한다.
+- `POST /organizations`: 이름을 받아 새 조직을 생성하고, 생성자를 admin으로 자동 등록한다.
+- `userRepo.ListUserOrganizations`: organizations와 user_organizations를 JOIN하여 id, name, plan, role을 한 번에 조회한다.
+- `userRepo.CreateOrganizationWithAdmin`: organizations INSERT와 user_organizations INSERT를 단일 트랜잭션으로 처리한다.
+- 새로 생성되는 조직의 기본 plan은 `"free"`, features는 `"[]"`로 설정한다.
+
+**이유**:
+- 회원가입 시 자동 생성되는 개인 조직 외에 팀/프로젝트 단위로 추가 조직을 만들 수 있어야 함
+- 다중 조직 멤버십을 가진 사용자가 조직 전환 UI를 구현하려면 전체 소속 목록이 필요함
+- org + membership을 단일 트랜잭션으로 처리하여 orphan 조직(멤버 없는 조직)이 생기지 않도록 보장
+
+**영향**: signsafe-web이 조직 선택/전환 UI를 구현할 때 `GET /users/me/organizations`를 사용해야 함
+
+---
+
 ## 2026-03-27: 비동기 작업 패턴 — Job ID 즉시 반환
 
 **결정**: 파싱, 분석 등 시간이 걸리는 모든 작업은 즉시 Job ID를 반환하고 RabbitMQ 큐에 위임한다.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -147,7 +147,9 @@ func main() {
 		r.Get("/users/me", authHandler.GetMe)
 		r.Patch("/users/me", orgHandler.UpdateProfile)
 		r.Patch("/users/me/password", orgHandler.ChangePassword)
+		r.Get("/users/me/organizations", orgHandler.ListMyOrganizations)
 
+		r.Post("/organizations", orgHandler.CreateOrganization)
 		r.Route("/organizations/{orgId}", func(r chi.Router) {
 			r.Get("/", orgHandler.GetOrganization)
 			r.Patch("/", orgHandler.UpdateOrganization)

--- a/internal/handler/org_handler.go
+++ b/internal/handler/org_handler.go
@@ -22,6 +22,43 @@ func NewOrgHandler(orgSvc *service.OrgService, authSvc *service.AuthService) *Or
 	return &OrgHandler{orgSvc: orgSvc, authSvc: authSvc}
 }
 
+// ListMyOrganizations handles GET /users/me/organizations
+func (h *OrgHandler) ListMyOrganizations(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.UserIDFromContext(r.Context())
+	orgs, err := h.orgSvc.ListMyOrganizations(r.Context(), userID)
+	if err != nil {
+		util.Error(w, http.StatusInternalServerError, "failed to list organizations")
+		return
+	}
+	util.JSON(w, http.StatusOK, orgs)
+}
+
+// CreateOrganization handles POST /organizations
+func (h *OrgHandler) CreateOrganization(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.UserIDFromContext(r.Context())
+	var body struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		util.Error(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if body.Name == "" {
+		util.Error(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	org, err := h.orgSvc.CreateOrganization(r.Context(), userID, body.Name)
+	if err != nil {
+		util.Error(w, http.StatusInternalServerError, "failed to create organization")
+		return
+	}
+	util.JSON(w, http.StatusCreated, map[string]interface{}{
+		"id":   org.ID,
+		"name": org.Name,
+		"plan": org.Plan,
+	})
+}
+
 // UpdateProfile handles PATCH /users/me
 func (h *OrgHandler) UpdateProfile(w http.ResponseWriter, r *http.Request) {
 	userID := middleware.UserIDFromContext(r.Context())

--- a/internal/repository/user_repo.go
+++ b/internal/repository/user_repo.go
@@ -311,6 +311,61 @@ func (r *UserRepo) GetMemberRole(ctx context.Context, userID, orgID string) (str
 	return role, nil
 }
 
+// UserOrganizationRow holds an organization together with the requesting user's role in it.
+type UserOrganizationRow struct {
+	ID   string `db:"id"`
+	Name string `db:"name"`
+	Plan string `db:"plan"`
+	Role string `db:"role"`
+}
+
+// ListUserOrganizations returns all organizations a user belongs to, including the user's role in each.
+func (r *UserRepo) ListUserOrganizations(ctx context.Context, userID string) ([]UserOrganizationRow, error) {
+	var rows []UserOrganizationRow
+	err := r.db.SelectContext(ctx, &rows, `
+		SELECT o.id, o.name, o.plan, uo.role
+		FROM organizations o
+		JOIN user_organizations uo ON uo.organization_id = o.id
+		WHERE uo.user_id = $1
+		ORDER BY uo.joined_at ASC`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("userRepo.ListUserOrganizations: %w", err)
+	}
+	return rows, nil
+}
+
+// CreateOrganizationWithAdmin inserts a new organization and adds the given user as admin in a single transaction.
+func (r *UserRepo) CreateOrganizationWithAdmin(ctx context.Context, org *model.Organization, userID string) error {
+	memberID := util.NewID()
+
+	tx, err := r.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("userRepo.CreateOrganizationWithAdmin: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO organizations (id, name, plan, features, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, NOW(), NOW())`,
+		org.ID, org.Name, org.Plan, org.Features,
+	); err != nil {
+		return fmt.Errorf("userRepo.CreateOrganizationWithAdmin: insert org: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO user_organizations (id, user_id, organization_id, role, permissions, joined_at)
+		VALUES ($1, $2, $3, 'admin', '[]', NOW())`,
+		memberID, userID, org.ID,
+	); err != nil {
+		return fmt.Errorf("userRepo.CreateOrganizationWithAdmin: insert membership: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("userRepo.CreateOrganizationWithAdmin: commit: %w", err)
+	}
+	return nil
+}
+
 // FindOrganizationByUserID returns the first organization a user belongs to.
 func (r *UserRepo) FindOrganizationByUserID(ctx context.Context, userID string) (*model.Organization, error) {
 	var org model.Organization

--- a/internal/service/org_service.go
+++ b/internal/service/org_service.go
@@ -25,6 +25,49 @@ func NewOrgService(userRepo *repository.UserRepo, emailClient *email.Client, app
 	return &OrgService{userRepo: userRepo, emailClient: emailClient, appURL: appURL}
 }
 
+// OrganizationSummary is the public view of an organization with the user's role.
+type OrganizationSummary struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Plan string `json:"plan"`
+	Role string `json:"role"`
+}
+
+// ListMyOrganizations returns all organizations that the given user belongs to.
+func (s *OrgService) ListMyOrganizations(ctx context.Context, userID string) ([]OrganizationSummary, error) {
+	rows, err := s.userRepo.ListUserOrganizations(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("orgService.ListMyOrganizations: %w", err)
+	}
+	out := make([]OrganizationSummary, len(rows))
+	for i, row := range rows {
+		out[i] = OrganizationSummary{
+			ID:   row.ID,
+			Name: row.Name,
+			Plan: row.Plan,
+			Role: row.Role,
+		}
+	}
+	return out, nil
+}
+
+// CreateOrganization creates a new organization and adds the requesting user as admin.
+func (s *OrgService) CreateOrganization(ctx context.Context, userID, name string) (*model.Organization, error) {
+	if name == "" {
+		return nil, fmt.Errorf("orgService.CreateOrganization: name cannot be empty")
+	}
+	org := &model.Organization{
+		ID:       util.NewID(),
+		Name:     name,
+		Plan:     "free",
+		Features: "[]",
+	}
+	if err := s.userRepo.CreateOrganizationWithAdmin(ctx, org, userID); err != nil {
+		return nil, fmt.Errorf("orgService.CreateOrganization: %w", err)
+	}
+	return org, nil
+}
+
 // GetOrganization returns an organization if the requesting user is a member.
 func (s *OrgService) GetOrganization(ctx context.Context, userID, orgID string) (*model.Organization, error) {
 	member, err := s.userRepo.IsOrgMember(ctx, userID, orgID)


### PR DESCRIPTION
## 변경사항

- `GET /users/me/organizations` — 인증된 사용자가 속한 모든 조직 목록 반환 (id, name, plan, role)
- `POST /organizations` — 새 조직 생성 (생성자 자동 admin 등록, plan 기본값 `free`)
- `userRepo.ListUserOrganizations` — organizations + user_organizations JOIN 쿼리
- `userRepo.CreateOrganizationWithAdmin` — 조직 생성 + admin 멤버십을 단일 트랜잭션 처리
- `orgService.ListMyOrganizations` / `orgService.CreateOrganization` 서비스 메서드 추가

## QA 결과

- `go build ./...` 성공
- `go vet ./...` 경고 없음
- raw SQL + sqlx 사용, ORM 미사용 확인
- 에러 래핑 패턴 (`fmt.Errorf("func: %w", err)`) 준수
- 조직+멤버십 생성 시 트랜잭션으로 원자성 보장

Closes #101