### PR TITLE
feat(#108): GET /audit-events 라우트 추가 (목록 조회, 날짜/액션 필터)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -189,7 +189,10 @@ func main() {
 			r.Post("/retrieve", evidenceHandler.RetrieveEvidence)
 		})
 
-		r.Post("/audit-events", auditHandler.CreateAuditEvent)
+		r.Route("/audit-events", func(r chi.Router) {
+			r.Get("/", auditHandler.ListAuditEvents)
+			r.Post("/", auditHandler.CreateAuditEvent)
+		})
 	})
 
 	// --- Server with graceful shutdown ---

--- a/internal/handler/audit_handler.go
+++ b/internal/handler/audit_handler.go
@@ -3,6 +3,8 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/signsafe-io/signsafe-api/internal/middleware"
 	"github.com/signsafe-io/signsafe-api/internal/service"
@@ -17,6 +19,79 @@ type AuditHandler struct {
 // NewAuditHandler creates a new AuditHandler.
 func NewAuditHandler(auditSvc *service.AuditService) *AuditHandler {
 	return &AuditHandler{auditSvc: auditSvc}
+}
+
+// ListAuditEvents handles GET /audit-events
+//
+// Query parameters:
+//
+//	organizationId (required)
+//	action         — filter by action type (optional)
+//	from           — ISO 8601 start date inclusive (optional)
+//	to             — ISO 8601 end date inclusive (optional)
+//	page           — 1-based page number (default 1)
+//	pageSize       — items per page (default 30, max 100)
+func (h *AuditHandler) ListAuditEvents(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	orgID := q.Get("organizationId")
+	if orgID == "" {
+		util.Error(w, http.StatusBadRequest, "organizationId is required")
+		return
+	}
+
+	// Verify the calling user belongs to the requested organization.
+	userID := middleware.UserIDFromContext(r.Context())
+	orgIDFromCtx := middleware.OrgIDFromContext(r.Context())
+	if orgIDFromCtx != "" && orgIDFromCtx != orgID {
+		util.Error(w, http.StatusForbidden, "access denied")
+		return
+	}
+	_ = userID // used implicitly via auth middleware
+
+	page, _ := strconv.Atoi(q.Get("page"))
+	pageSize, _ := strconv.Atoi(q.Get("pageSize"))
+
+	req := service.ListAuditEventsRequest{
+		OrganizationID: orgID,
+		Action:         q.Get("action"),
+		Page:           page,
+		PageSize:       pageSize,
+	}
+
+	if fromStr := q.Get("from"); fromStr != "" {
+		t, err := time.Parse(time.RFC3339, fromStr)
+		if err != nil {
+			// Accept date-only format too.
+			t, err = time.Parse("2006-01-02", fromStr)
+			if err != nil {
+				util.Error(w, http.StatusBadRequest, "invalid 'from' date (use ISO 8601)")
+				return
+			}
+		}
+		req.From = &t
+	}
+	if toStr := q.Get("to"); toStr != "" {
+		t, err := time.Parse(time.RFC3339, toStr)
+		if err != nil {
+			t, err = time.Parse("2006-01-02", toStr)
+			if err != nil {
+				util.Error(w, http.StatusBadRequest, "invalid 'to' date (use ISO 8601)")
+				return
+			}
+			// Inclusive end: shift to end of day.
+			t = t.Add(24*time.Hour - time.Nanosecond)
+		}
+		req.To = &t
+	}
+
+	resp, err := h.auditSvc.ListAuditEvents(r.Context(), req)
+	if err != nil {
+		util.Error(w, http.StatusInternalServerError, "failed to list audit events")
+		return
+	}
+
+	util.JSON(w, http.StatusOK, resp)
 }
 
 // CreateAuditEvent handles POST /audit-events

--- a/internal/repository/audit_repo.go
+++ b/internal/repository/audit_repo.go
@@ -3,6 +3,8 @@ package repository
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/signsafe-io/signsafe-api/internal/model"
@@ -31,4 +33,82 @@ func (r *AuditRepo) CreateAuditEvent(ctx context.Context, e *model.AuditEvent) e
 		return fmt.Errorf("auditRepo.CreateAuditEvent: %w", err)
 	}
 	return nil
+}
+
+// ListAuditEventsFilter holds optional filter parameters for listing audit events.
+type ListAuditEventsFilter struct {
+	OrganizationID string
+	Action         string
+	From           *time.Time
+	To             *time.Time
+	Page           int
+	PageSize       int
+}
+
+// ListAuditEventsResult holds a page of audit events and total count.
+type ListAuditEventsResult struct {
+	Events []*model.AuditEvent
+	Total  int
+}
+
+// ListAuditEvents returns a paginated list of audit events for an organization.
+func (r *AuditRepo) ListAuditEvents(ctx context.Context, f ListAuditEventsFilter) (*ListAuditEventsResult, error) {
+	if f.Page < 1 {
+		f.Page = 1
+	}
+	if f.PageSize < 1 || f.PageSize > 100 {
+		f.PageSize = 30
+	}
+	offset := (f.Page - 1) * f.PageSize
+
+	// Build dynamic WHERE clause.
+	conditions := []string{"organization_id = $1"}
+	args := []any{f.OrganizationID}
+	idx := 2
+
+	if f.Action != "" {
+		conditions = append(conditions, fmt.Sprintf("action = $%d", idx))
+		args = append(args, f.Action)
+		idx++
+	}
+	if f.From != nil {
+		conditions = append(conditions, fmt.Sprintf("created_at >= $%d", idx))
+		args = append(args, *f.From)
+		idx++
+	}
+	if f.To != nil {
+		conditions = append(conditions, fmt.Sprintf("created_at <= $%d", idx))
+		args = append(args, *f.To)
+		idx++
+	}
+
+	where := "WHERE " + strings.Join(conditions, " AND ")
+
+	// Count total matching events.
+	var total int
+	countQ := fmt.Sprintf("SELECT COUNT(*) FROM audit_events %s", where)
+	if err := r.db.QueryRowContext(ctx, countQ, args...).Scan(&total); err != nil {
+		return nil, fmt.Errorf("auditRepo.ListAuditEvents count: %w", err)
+	}
+
+	// Fetch page.
+	listQ := fmt.Sprintf(`
+		SELECT id, actor_id, actor_email, action, target_type, target_id,
+		       organization_id, context, ip_address, user_agent, created_at
+		FROM audit_events
+		%s
+		ORDER BY created_at DESC
+		LIMIT $%d OFFSET $%d`, where, idx, idx+1)
+
+	args = append(args, f.PageSize, offset)
+
+	var events []*model.AuditEvent
+	if err := r.db.SelectContext(ctx, &events, listQ, args...); err != nil {
+		return nil, fmt.Errorf("auditRepo.ListAuditEvents select: %w", err)
+	}
+	if events == nil {
+		events = []*model.AuditEvent{}
+	}
+
+	return &ListAuditEventsResult{Events: events, Total: total}, nil
 }

--- a/internal/service/audit_service.go
+++ b/internal/service/audit_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/signsafe-io/signsafe-api/internal/model"
 	"github.com/signsafe-io/signsafe-api/internal/repository"
@@ -55,4 +56,51 @@ func (s *AuditService) CreateAuditEvent(ctx context.Context, req CreateAuditEven
 		return nil, fmt.Errorf("auditService.CreateAuditEvent: %w", err)
 	}
 	return e, nil
+}
+
+// ListAuditEventsRequest holds parameters for listing audit events.
+type ListAuditEventsRequest struct {
+	OrganizationID string
+	Action         string
+	From           *time.Time
+	To             *time.Time
+	Page           int
+	PageSize       int
+}
+
+// ListAuditEventsResponse is returned by ListAuditEvents.
+type ListAuditEventsResponse struct {
+	Events   []*model.AuditEvent `json:"events"`
+	Total    int                 `json:"total"`
+	Page     int                 `json:"page"`
+	PageSize int                 `json:"pageSize"`
+}
+
+// ListAuditEvents returns a filtered, paginated list of audit events.
+func (s *AuditService) ListAuditEvents(ctx context.Context, req ListAuditEventsRequest) (*ListAuditEventsResponse, error) {
+	if req.Page < 1 {
+		req.Page = 1
+	}
+	if req.PageSize < 1 || req.PageSize > 100 {
+		req.PageSize = 30
+	}
+
+	result, err := s.auditRepo.ListAuditEvents(ctx, repository.ListAuditEventsFilter{
+		OrganizationID: req.OrganizationID,
+		Action:         req.Action,
+		From:           req.From,
+		To:             req.To,
+		Page:           req.Page,
+		PageSize:       req.PageSize,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("auditService.ListAuditEvents: %w", err)
+	}
+
+	return &ListAuditEventsResponse{
+		Events:   result.Events,
+		Total:    result.Total,
+		Page:     req.Page,
+		PageSize: req.PageSize,
+	}, nil
 }


### PR DESCRIPTION
## 변경사항

- `internal/repository/audit_repo.go`: `ListAuditEvents()` 추가
  - `organizationId` 필수 필터
  - `action` / `from` / `to` 선택 필터 (동적 WHERE 절 구성)
  - `OFFSET/LIMIT` 페이지네이션, `created_at DESC` 정렬
  - `COUNT(*)` 총 건수 반환
- `internal/service/audit_service.go`: `ListAuditEvents()` + 요청/응답 타입
- `internal/handler/audit_handler.go`: `ListAuditEvents()` 핸들러
  - `from`/`to`: RFC3339 또는 `YYYY-MM-DD` 형식 지원
  - `to` 날짜 전용 시 해당 일 23:59:59.999 로 확장 (inclusive)
  - JWT orgId와 요청 orgId 불일치 시 403
- `cmd/server/main.go`: `/audit-events` Route로 변경
  - `GET /` → `ListAuditEvents`
  - `POST /` → `CreateAuditEvent`

## QA 결과

- `go build ./...` 통과
- 기존 POST /audit-events 동작 유지

Closes #108