### PR TITLE
feat(#110): GET /organizations/{orgId}/stats 대시보드 통계 API

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -106,6 +106,9 @@ func main() {
 	auditRepo := repository.NewAuditRepo(db)
 	auditSvc := service.NewAuditService(auditRepo)
 
+	statsRepo := repository.NewStatsRepo(db)
+	statsSvc := service.NewStatsService(statsRepo, userRepo)
+
 	// --- Handlers ---
 	authHandler := handler.NewAuthHandler(authSvc, orgSvc)
 	orgHandler := handler.NewOrgHandler(orgSvc, authSvc)
@@ -113,6 +116,7 @@ func main() {
 	analysisHandler := handler.NewAnalysisHandler(analysisSvc, auditSvc)
 	evidenceHandler := handler.NewEvidenceHandler(evidenceSvc)
 	auditHandler := handler.NewAuditHandler(auditSvc)
+	statsHandler := handler.NewStatsHandler(statsSvc)
 
 	// --- Router ---
 	r := chi.NewRouter()
@@ -157,6 +161,7 @@ func main() {
 			r.Post("/members", orgHandler.InviteMember)
 			r.Patch("/members/{userId}", orgHandler.UpdateMemberRole)
 			r.Delete("/members/{userId}", orgHandler.RemoveMember)
+			r.Get("/stats", statsHandler.GetOrgStats)
 		})
 
 		r.Route("/contracts", func(r chi.Router) {

--- a/internal/handler/stats_handler.go
+++ b/internal/handler/stats_handler.go
@@ -1,0 +1,39 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/signsafe-io/signsafe-api/internal/middleware"
+	"github.com/signsafe-io/signsafe-api/internal/service"
+	"github.com/signsafe-io/signsafe-api/internal/util"
+)
+
+// StatsHandler handles dashboard statistics requests.
+type StatsHandler struct {
+	statsSvc *service.StatsService
+}
+
+// NewStatsHandler creates a new StatsHandler.
+func NewStatsHandler(statsSvc *service.StatsService) *StatsHandler {
+	return &StatsHandler{statsSvc: statsSvc}
+}
+
+// GetOrgStats handles GET /organizations/{orgId}/stats
+func (h *StatsHandler) GetOrgStats(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.UserIDFromContext(r.Context())
+	orgID := chi.URLParam(r, "orgId")
+
+	stats, err := h.statsSvc.GetDashboardStats(r.Context(), userID, orgID)
+	if err != nil {
+		if errors.Is(err, service.ErrAccessDenied) {
+			util.Error(w, http.StatusForbidden, "access denied")
+			return
+		}
+		util.Error(w, http.StatusInternalServerError, "failed to fetch stats")
+		return
+	}
+
+	util.JSON(w, http.StatusOK, stats)
+}

--- a/internal/repository/stats_repo.go
+++ b/internal/repository/stats_repo.go
@@ -1,0 +1,106 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// OrgStats holds aggregated statistics for an organization.
+type OrgStats struct {
+	TotalContracts      int `db:"total_contracts"      json:"totalContracts"`
+	UploadedContracts   int `db:"uploaded_contracts"   json:"uploadedContracts"`
+	ProcessingContracts int `db:"processing_contracts" json:"processingContracts"`
+	ReadyContracts      int `db:"ready_contracts"      json:"readyContracts"`
+	FailedContracts     int `db:"failed_contracts"     json:"failedContracts"`
+	RecentAnalyses      int `db:"recent_analyses"      json:"recentAnalyses"` // last 30 days
+}
+
+// RiskDistribution holds the count of clause results at each risk level for an org.
+type RiskDistribution struct {
+	HighCount   int `db:"high_count"   json:"highCount"`
+	MediumCount int `db:"medium_count" json:"mediumCount"`
+	LowCount    int `db:"low_count"    json:"lowCount"`
+}
+
+// RecentContract is a lightweight summary of a contract for the dashboard.
+type RecentContract struct {
+	ID        string `db:"id"         json:"id"`
+	Title     string `db:"title"      json:"title"`
+	Status    string `db:"status"     json:"status"`
+	CreatedAt string `db:"created_at" json:"createdAt"`
+}
+
+// StatsRepo handles aggregated statistics queries.
+type StatsRepo struct {
+	db *sqlx.DB
+}
+
+// NewStatsRepo creates a new StatsRepo.
+func NewStatsRepo(db *sqlx.DB) *StatsRepo {
+	return &StatsRepo{db: db}
+}
+
+// GetOrgStats returns contract counts and recent analysis count for an org.
+func (r *StatsRepo) GetOrgStats(ctx context.Context, orgID string) (*OrgStats, error) {
+	var s OrgStats
+	err := r.db.GetContext(ctx, &s, `
+		SELECT
+			COUNT(*)                                                         AS total_contracts,
+			COUNT(*) FILTER (WHERE status = 'uploaded')                     AS uploaded_contracts,
+			COUNT(*) FILTER (WHERE status = 'processing')                   AS processing_contracts,
+			COUNT(*) FILTER (WHERE status = 'ready')                        AS ready_contracts,
+			COUNT(*) FILTER (WHERE status = 'failed')                       AS failed_contracts,
+			(
+				SELECT COUNT(*)
+				FROM risk_analyses ra
+				JOIN contracts c2 ON c2.id = ra.contract_id
+				WHERE c2.organization_id = $1
+				  AND ra.created_at >= NOW() - INTERVAL '30 days'
+			)                                                                AS recent_analyses
+		FROM contracts
+		WHERE organization_id = $1`,
+		orgID)
+	if err != nil {
+		return nil, fmt.Errorf("statsRepo.GetOrgStats: %w", err)
+	}
+	return &s, nil
+}
+
+// GetRiskDistribution returns the count of HIGH/MEDIUM/LOW clause results from
+// completed analyses for contracts belonging to the org.
+func (r *StatsRepo) GetRiskDistribution(ctx context.Context, orgID string) (*RiskDistribution, error) {
+	var d RiskDistribution
+	err := r.db.GetContext(ctx, &d, `
+		SELECT
+			COUNT(*) FILTER (WHERE cr.risk_level = 'HIGH')   AS high_count,
+			COUNT(*) FILTER (WHERE cr.risk_level = 'MEDIUM') AS medium_count,
+			COUNT(*) FILTER (WHERE cr.risk_level = 'LOW')    AS low_count
+		FROM clause_results cr
+		JOIN risk_analyses ra ON ra.id = cr.analysis_id
+		JOIN contracts c      ON c.id  = ra.contract_id
+		WHERE c.organization_id = $1
+		  AND ra.status = 'completed'`,
+		orgID)
+	if err != nil {
+		return nil, fmt.Errorf("statsRepo.GetRiskDistribution: %w", err)
+	}
+	return &d, nil
+}
+
+// ListRecentContracts returns the most recent contracts for an org.
+func (r *StatsRepo) ListRecentContracts(ctx context.Context, orgID string, limit int) ([]RecentContract, error) {
+	var contracts []RecentContract
+	err := r.db.SelectContext(ctx, &contracts, `
+		SELECT id, title, status, created_at::text
+		FROM contracts
+		WHERE organization_id = $1
+		ORDER BY created_at DESC
+		LIMIT $2`,
+		orgID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("statsRepo.ListRecentContracts: %w", err)
+	}
+	return contracts, nil
+}

--- a/internal/service/stats_service.go
+++ b/internal/service/stats_service.go
@@ -1,0 +1,73 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/signsafe-io/signsafe-api/internal/repository"
+)
+
+// DashboardStats is the full response for the dashboard statistics endpoint.
+type DashboardStats struct {
+	TotalContracts      int                         `json:"totalContracts"`
+	UploadedContracts   int                         `json:"uploadedContracts"`
+	ProcessingContracts int                         `json:"processingContracts"`
+	ReadyContracts      int                         `json:"readyContracts"`
+	FailedContracts     int                         `json:"failedContracts"`
+	RecentAnalyses      int                         `json:"recentAnalyses"`
+	RiskDistribution    repository.RiskDistribution `json:"riskDistribution"`
+	RecentContracts     []repository.RecentContract `json:"recentContracts"`
+}
+
+// StatsService provides aggregated statistics for organizations.
+type StatsService struct {
+	statsRepo *repository.StatsRepo
+	userRepo  *repository.UserRepo
+}
+
+// NewStatsService creates a new StatsService.
+func NewStatsService(statsRepo *repository.StatsRepo, userRepo *repository.UserRepo) *StatsService {
+	return &StatsService{statsRepo: statsRepo, userRepo: userRepo}
+}
+
+// GetDashboardStats returns aggregated statistics for the given organization.
+// It verifies that the requesting user is a member of the org before querying.
+func (s *StatsService) GetDashboardStats(ctx context.Context, userID, orgID string) (*DashboardStats, error) {
+	// Verify membership.
+	isMember, err := s.userRepo.IsOrgMember(ctx, userID, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("statsService.GetDashboardStats: check membership: %w", err)
+	}
+	if !isMember {
+		return nil, ErrAccessDenied
+	}
+
+	// Fetch contract counts + recent analyses count.
+	orgStats, err := s.statsRepo.GetOrgStats(ctx, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("statsService.GetDashboardStats: org stats: %w", err)
+	}
+
+	// Fetch risk distribution.
+	riskDist, err := s.statsRepo.GetRiskDistribution(ctx, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("statsService.GetDashboardStats: risk distribution: %w", err)
+	}
+
+	// Fetch recent 5 contracts.
+	recentContracts, err := s.statsRepo.ListRecentContracts(ctx, orgID, 5)
+	if err != nil {
+		return nil, fmt.Errorf("statsService.GetDashboardStats: recent contracts: %w", err)
+	}
+
+	return &DashboardStats{
+		TotalContracts:      orgStats.TotalContracts,
+		UploadedContracts:   orgStats.UploadedContracts,
+		ProcessingContracts: orgStats.ProcessingContracts,
+		ReadyContracts:      orgStats.ReadyContracts,
+		FailedContracts:     orgStats.FailedContracts,
+		RecentAnalyses:      orgStats.RecentAnalyses,
+		RiskDistribution:    *riskDist,
+		RecentContracts:     recentContracts,
+	}, nil
+}


### PR DESCRIPTION
## 변경사항
- StatsRepo 추가: 상태별 계약 수 + 최근 30일 분석 건수 집계 쿼리, 리스크 분포(HIGH/MEDIUM/LOW), 최근 계약 5건 조회
- StatsService 추가: 멤버십 검증 후 세 쿼리 결과를 DashboardStats로 합산
- StatsHandler 추가: GET /organizations/{orgId}/stats — 인증 필요, 비멤버 403
- main.go 업데이트: 의존성 등록 및 라우트 연결

## QA 결과
- go build ./... 통과
- go test ./... 통과

Closes #110