### PR TITLE
feat(#112): 만료 임박 계약 조회 엔드포인트 추가

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -162,6 +162,7 @@ func main() {
 			r.Patch("/members/{userId}", orgHandler.UpdateMemberRole)
 			r.Delete("/members/{userId}", orgHandler.RemoveMember)
 			r.Get("/stats", statsHandler.GetOrgStats)
+			r.Get("/contracts/expiring-soon", contractHandler.ListExpiringSoon)
 		})
 
 		r.Route("/contracts", func(r chi.Router) {

--- a/internal/handler/contract_handler.go
+++ b/internal/handler/contract_handler.go
@@ -139,6 +139,35 @@ func (h *ContractHandler) List(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// ListExpiringSoon handles GET /organizations/{orgId}/contracts/expiring-soon
+// Query params:
+//   - days (int, default 30): return contracts expiring within this many days
+func (h *ContractHandler) ListExpiringSoon(w http.ResponseWriter, r *http.Request) {
+	orgID := chi.URLParam(r, "orgId")
+	userID := middleware.UserIDFromContext(r.Context())
+
+	days := 30
+	if d, err := strconv.Atoi(r.URL.Query().Get("days")); err == nil && d > 0 {
+		days = d
+	}
+
+	contracts, err := h.contractSvc.ListExpiringContracts(r.Context(), orgID, userID, days)
+	if err != nil {
+		if errors.Is(err, service.ErrAccessDenied) {
+			util.Error(w, http.StatusForbidden, "access denied")
+			return
+		}
+		util.Error(w, http.StatusInternalServerError, "failed to list expiring contracts")
+		return
+	}
+
+	util.JSON(w, http.StatusOK, map[string]interface{}{
+		"contracts": contracts,
+		"total":     len(contracts),
+		"days":      days,
+	})
+}
+
 // Get handles GET /contracts/{contractId}
 func (h *ContractHandler) Get(w http.ResponseWriter, r *http.Request) {
 	contractID := chi.URLParam(r, "contractId")

--- a/internal/repository/contract_repo.go
+++ b/internal/repository/contract_repo.go
@@ -109,6 +109,25 @@ func (r *ContractRepo) ListContracts(ctx context.Context, orgID string, limit, o
 	return contracts, total, nil
 }
 
+// ListExpiringContracts returns contracts expiring within the given number of days,
+// ordered by expires_at ascending (soonest first).
+// Only contracts with a non-null expires_at in the future (and within the window) are returned.
+func (r *ContractRepo) ListExpiringContracts(ctx context.Context, orgID string, days int) ([]model.Contract, error) {
+	var contracts []model.Contract
+	err := r.db.SelectContext(ctx, &contracts, `
+		SELECT * FROM contracts
+		WHERE organization_id = $1
+		  AND expires_at IS NOT NULL
+		  AND expires_at > NOW()
+		  AND expires_at <= NOW() + ($2 * INTERVAL '1 day')
+		ORDER BY expires_at ASC`,
+		orgID, days)
+	if err != nil {
+		return nil, fmt.Errorf("contractRepo.ListExpiringContracts: %w", err)
+	}
+	return contracts, nil
+}
+
 // CreateIngestionJob inserts a new ingestion job.
 func (r *ContractRepo) CreateIngestionJob(ctx context.Context, job *model.IngestionJob) error {
 	_, err := r.db.ExecContext(ctx, `

--- a/internal/repository/stats_repo.go
+++ b/internal/repository/stats_repo.go
@@ -15,6 +15,7 @@ type OrgStats struct {
 	ReadyContracts      int `db:"ready_contracts"      json:"readyContracts"`
 	FailedContracts     int `db:"failed_contracts"     json:"failedContracts"`
 	RecentAnalyses      int `db:"recent_analyses"      json:"recentAnalyses"` // last 30 days
+	ExpiringSoon        int `db:"expiring_soon"        json:"expiringSoon"`   // expires within 30 days
 }
 
 // RiskDistribution holds the count of clause results at each risk level for an org.
@@ -58,7 +59,12 @@ func (r *StatsRepo) GetOrgStats(ctx context.Context, orgID string) (*OrgStats, e
 				JOIN contracts c2 ON c2.id = ra.contract_id
 				WHERE c2.organization_id = $1
 				  AND ra.created_at >= NOW() - INTERVAL '30 days'
-			)                                                                AS recent_analyses
+			)                                                                AS recent_analyses,
+			COUNT(*) FILTER (
+				WHERE expires_at IS NOT NULL
+				  AND expires_at > NOW()
+				  AND expires_at <= NOW() + INTERVAL '30 days'
+			)                                                                AS expiring_soon
 		FROM contracts
 		WHERE organization_id = $1`,
 		orgID)

--- a/internal/service/contract_service.go
+++ b/internal/service/contract_service.go
@@ -189,6 +189,28 @@ func (s *ContractService) ListContracts(ctx context.Context, orgID string, page,
 	return contracts, total, nil
 }
 
+// ListExpiringContracts returns contracts expiring within the given number of days.
+// The user must be a member of the organization.
+func (s *ContractService) ListExpiringContracts(ctx context.Context, orgID, userID string, days int) ([]model.Contract, error) {
+	member, err := s.userRepo.IsOrgMember(ctx, userID, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("contractService.ListExpiringContracts: check membership: %w", err)
+	}
+	if !member {
+		return nil, ErrAccessDenied
+	}
+
+	if days < 1 || days > 365 {
+		days = 30
+	}
+
+	contracts, err := s.repo.ListExpiringContracts(ctx, orgID, days)
+	if err != nil {
+		return nil, fmt.Errorf("contractService.ListExpiringContracts: %w", err)
+	}
+	return contracts, nil
+}
+
 // GetContract returns a single contract by ID.
 func (s *ContractService) GetContract(ctx context.Context, contractID string) (*model.Contract, error) {
 	c, err := s.repo.FindContractByID(ctx, contractID)

--- a/internal/service/stats_service.go
+++ b/internal/service/stats_service.go
@@ -15,6 +15,7 @@ type DashboardStats struct {
 	ReadyContracts      int                         `json:"readyContracts"`
 	FailedContracts     int                         `json:"failedContracts"`
 	RecentAnalyses      int                         `json:"recentAnalyses"`
+	ExpiringSoon        int                         `json:"expiringSoon"` // expires within 30 days
 	RiskDistribution    repository.RiskDistribution `json:"riskDistribution"`
 	RecentContracts     []repository.RecentContract `json:"recentContracts"`
 }
@@ -67,6 +68,7 @@ func (s *StatsService) GetDashboardStats(ctx context.Context, userID, orgID stri
 		ReadyContracts:      orgStats.ReadyContracts,
 		FailedContracts:     orgStats.FailedContracts,
 		RecentAnalyses:      orgStats.RecentAnalyses,
+		ExpiringSoon:        orgStats.ExpiringSoon,
 		RiskDistribution:    *riskDist,
 		RecentContracts:     recentContracts,
 	}, nil


### PR DESCRIPTION
## 변경사항
- GET /organizations/{orgId}/contracts/expiring-soon 신규 엔드포인트
  - ?days 파라미터 (기본 30, 최대 365): 만료 임박 기간 지정
  - expires_at > NOW() AND expires_at <= NOW() + (days * INTERVAL '1 day') 조건
  - expires_at ASC 정렬 (가장 임박한 계약 먼저)
  - 조직 멤버십 미충족 시 403 반환
- DashboardStats 응답에 expiringSoon 카운트 필드 추가 (30일 이내 기준)
- ContractRepo.ListExpiringContracts 추가
- ContractService.ListExpiringContracts 추가 (ErrAccessDenied 처리)

## QA 결과
- go build ./... 통과
- go test ./... 통과

Closes #112