### PR TITLE
feat(#114): ListMembers 응답에 emailVerified 필드 추가

### DIFF
--- a/internal/repository/user_repo.go
+++ b/internal/repository/user_repo.go
@@ -434,18 +434,19 @@ func (r *UserRepo) UpdateFullName(ctx context.Context, userID, fullName string) 
 
 // OrgMember holds member info returned by ListOrgMembers.
 type OrgMember struct {
-	UserID   string    `db:"user_id"`
-	Email    string    `db:"email"`
-	FullName string    `db:"full_name"`
-	Role     string    `db:"role"`
-	JoinedAt time.Time `db:"joined_at"`
+	UserID        string    `db:"user_id"`
+	Email         string    `db:"email"`
+	FullName      string    `db:"full_name"`
+	Role          string    `db:"role"`
+	JoinedAt      time.Time `db:"joined_at"`
+	EmailVerified bool      `db:"email_verified"`
 }
 
 // ListOrgMembers returns all members of an organization.
 func (r *UserRepo) ListOrgMembers(ctx context.Context, orgID string) ([]OrgMember, error) {
 	var members []OrgMember
 	err := r.db.SelectContext(ctx, &members, `
-		SELECT uo.user_id, u.email, u.full_name, uo.role, uo.joined_at
+		SELECT uo.user_id, u.email, u.full_name, uo.role, uo.joined_at, u.email_verified
 		FROM user_organizations uo
 		JOIN users u ON u.id = uo.user_id
 		WHERE uo.organization_id = $1

--- a/internal/service/org_service.go
+++ b/internal/service/org_service.go
@@ -108,11 +108,12 @@ func (s *OrgService) UpdateOrganization(ctx context.Context, userID, orgID, name
 
 // MemberInfo is the public view of a member.
 type MemberInfo struct {
-	UserID   string `json:"userId"`
-	Email    string `json:"email"`
-	FullName string `json:"fullName"`
-	Role     string `json:"role"`
-	JoinedAt string `json:"joinedAt"`
+	UserID        string `json:"userId"`
+	Email         string `json:"email"`
+	FullName      string `json:"fullName"`
+	Role          string `json:"role"`
+	JoinedAt      string `json:"joinedAt"`
+	EmailVerified bool   `json:"emailVerified"`
 }
 
 // ListMembers returns members of an org if the requesting user is a member.
@@ -131,11 +132,12 @@ func (s *OrgService) ListMembers(ctx context.Context, userID, orgID string) ([]M
 	out := make([]MemberInfo, len(rows))
 	for i, m := range rows {
 		out[i] = MemberInfo{
-			UserID:   m.UserID,
-			Email:    m.Email,
-			FullName: m.FullName,
-			Role:     m.Role,
-			JoinedAt: m.JoinedAt.Format("2006-01-02T15:04:05Z"),
+			UserID:        m.UserID,
+			Email:         m.Email,
+			FullName:      m.FullName,
+			Role:          m.Role,
+			JoinedAt:      m.JoinedAt.Format("2006-01-02T15:04:05Z"),
+			EmailVerified: m.EmailVerified,
 		}
 	}
 	return out, nil


### PR DESCRIPTION
## 변경사항
- OrgMember.EmailVerified bool 필드 추가 (db:"email_verified")
- ListOrgMembers SQL에 u.email_verified 컬럼 포함
- MemberInfo.EmailVerified bool 필드 추가 (json:"emailVerified")
- 이메일 미인증 멤버를 프론트엔드에서 식별하여 초대 재전송 버튼 표시 가능

## QA 결과
- go build ./... 통과

Closes #114