### PR TITLE
feat(#116): 계약 만료 알림 이메일 크론 잡

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -18,6 +19,7 @@ import (
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
 
 	"github.com/signsafe-io/signsafe-api/internal/cache"
+	"github.com/signsafe-io/signsafe-api/internal/cron"
 	"github.com/signsafe-io/signsafe-api/internal/email"
 	"github.com/signsafe-io/signsafe-api/internal/handler"
 	"github.com/signsafe-io/signsafe-api/internal/middleware"
@@ -45,6 +47,7 @@ func main() {
 	smtpPass := getEnv("SMTP_PASS", "")
 	smtpFrom := getEnv("SMTP_FROM", "")
 	appBaseURL := getEnv("APP_BASE_URL", "https://signsafe-web.dsmhs.kr")
+	expiryAlertDays := getEnvInt("EXPIRY_ALERT_DAYS", 30)
 
 	// --- DB ---
 	db, err := repository.NewDB(databaseURL)
@@ -201,15 +204,19 @@ func main() {
 		})
 	})
 
+	// --- Background jobs ---
+	// Listen for OS signals in a goroutine.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	expiryNotifier := cron.NewExpiryNotifier(userRepo, contractRepo, cacheClient, emailClient, expiryAlertDays)
+	go expiryNotifier.Start(ctx)
+
 	// --- Server with graceful shutdown ---
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%s", port),
 		Handler: r,
 	}
-
-	// Listen for OS signals in a goroutine.
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
-	defer stop()
 
 	go func() {
 		slog.Info("server starting", "addr", srv.Addr)
@@ -291,6 +298,15 @@ func makeHealthHandler(db dbPinger, cacheClient *cache.Client, queueClient *queu
 func getEnv(key, fallback string) string {
 	if v, ok := os.LookupEnv(key); ok {
 		return v
+	}
+	return fallback
+}
+
+func getEnvInt(key string, fallback int) int {
+	if v, ok := os.LookupEnv(key); ok {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
 	}
 	return fallback
 }

--- a/internal/cron/expiry_notifier.go
+++ b/internal/cron/expiry_notifier.go
@@ -1,0 +1,157 @@
+// Package cron contains scheduled background jobs.
+package cron
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/signsafe-io/signsafe-api/internal/cache"
+	"github.com/signsafe-io/signsafe-api/internal/email"
+	"github.com/signsafe-io/signsafe-api/internal/repository"
+)
+
+// ExpiryNotifier sends expiry-alert emails to org admins on a daily schedule.
+type ExpiryNotifier struct {
+	userRepo     *repository.UserRepo
+	contractRepo *repository.ContractRepo
+	cacheClient  *cache.Client
+	emailClient  *email.Client
+	alertDays    int
+}
+
+// NewExpiryNotifier creates an ExpiryNotifier.
+// alertDays controls how far in advance to warn (e.g. 30 means "expiring within 30 days").
+func NewExpiryNotifier(
+	userRepo *repository.UserRepo,
+	contractRepo *repository.ContractRepo,
+	cacheClient *cache.Client,
+	emailClient *email.Client,
+	alertDays int,
+) *ExpiryNotifier {
+	if alertDays <= 0 {
+		alertDays = 30
+	}
+	return &ExpiryNotifier{
+		userRepo:     userRepo,
+		contractRepo: contractRepo,
+		cacheClient:  cacheClient,
+		emailClient:  emailClient,
+		alertDays:    alertDays,
+	}
+}
+
+// Start launches the daily notification loop. It blocks until ctx is cancelled.
+// The first run fires at the next 00:00 KST; subsequent runs fire every 24 h.
+func (n *ExpiryNotifier) Start(ctx context.Context) {
+	nextRun := nextMidnightKST()
+	slog.Info("expiry notifier: scheduled", "first_run", nextRun.Format(time.RFC3339))
+
+	timer := time.NewTimer(time.Until(nextRun))
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("expiry notifier: shutting down")
+			return
+		case <-timer.C:
+			n.run(ctx)
+			// Schedule next run 24 h later.
+			timer.Reset(24 * time.Hour)
+		}
+	}
+}
+
+// RunOnce executes the notification job synchronously (useful for testing / forced runs).
+func (n *ExpiryNotifier) RunOnce(ctx context.Context) {
+	n.run(ctx)
+}
+
+// run fetches all organizations and sends alerts for those with expiring contracts.
+func (n *ExpiryNotifier) run(ctx context.Context) {
+	slog.Info("expiry notifier: run started", "alert_days", n.alertDays)
+
+	orgs, err := n.userRepo.ListAllOrganizations(ctx)
+	if err != nil {
+		slog.Error("expiry notifier: list orgs failed", "error", err)
+		return
+	}
+
+	today := time.Now().UTC().Format("2006-01-02")
+	sent, skipped, failed := 0, 0, 0
+
+	for _, org := range orgs {
+		contracts, err := n.contractRepo.ListExpiringContracts(ctx, org.ID, n.alertDays)
+		if err != nil {
+			slog.Warn("expiry notifier: list contracts failed", "org_id", org.ID, "error", err)
+			failed++
+			continue
+		}
+		if len(contracts) == 0 {
+			skipped++
+			continue
+		}
+
+		// De-duplicate: only send once per org per calendar day.
+		dedupKey := fmt.Sprintf("expiry-notified:%s:%s", org.ID, today)
+		ok, err := n.cacheClient.SetNX(ctx, dedupKey, "1", 25*time.Hour)
+		if err != nil {
+			slog.Warn("expiry notifier: dedup check failed", "org_id", org.ID, "error", err)
+			// Fall through and attempt to send anyway to avoid silent skips.
+		} else if !ok {
+			slog.Debug("expiry notifier: already sent today", "org_id", org.ID)
+			skipped++
+			continue
+		}
+
+		// Convert model.Contract slice to ExpiringContractInfo slice.
+		infos := make([]email.ExpiringContractInfo, 0, len(contracts))
+		for _, c := range contracts {
+			if c.ExpiresAt == nil {
+				continue
+			}
+			infos = append(infos, email.ExpiringContractInfo{
+				Title:     c.Title,
+				ExpiresAt: *c.ExpiresAt,
+			})
+		}
+		if len(infos) == 0 {
+			skipped++
+			continue
+		}
+
+		// Fetch admin emails.
+		admins, err := n.userRepo.ListOrgAdmins(ctx, org.ID)
+		if err != nil || len(admins) == 0 {
+			slog.Warn("expiry notifier: no admins found", "org_id", org.ID, "error", err)
+			skipped++
+			continue
+		}
+
+		for _, admin := range admins {
+			if err := n.emailClient.SendExpiryAlertEmail(admin.Email, org.Name, infos, n.alertDays); err != nil {
+				slog.Warn("expiry notifier: send failed", "to", admin.Email, "org_id", org.ID, "error", err)
+				failed++
+			} else {
+				slog.Info("expiry notifier: alert sent", "to", admin.Email, "org", org.Name, "contracts", len(infos))
+				sent++
+			}
+		}
+	}
+
+	slog.Info("expiry notifier: run complete", "sent", sent, "skipped", skipped, "failed", failed)
+}
+
+// nextMidnightKST returns the next 00:00:00 in Asia/Seoul (KST = UTC+9).
+// Falls back to UTC+9 fixed offset if the timezone database is unavailable.
+func nextMidnightKST() time.Time {
+	loc, err := time.LoadLocation("Asia/Seoul")
+	if err != nil {
+		loc = time.FixedZone("KST", 9*60*60)
+	}
+	now := time.Now().In(loc)
+	midnight := time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, loc)
+	return midnight
+}

--- a/internal/cron/expiry_notifier_test.go
+++ b/internal/cron/expiry_notifier_test.go
@@ -1,0 +1,38 @@
+package cron
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNextMidnightKST(t *testing.T) {
+	got := nextMidnightKST()
+
+	loc, err := time.LoadLocation("Asia/Seoul")
+	if err != nil {
+		loc = time.FixedZone("KST", 9*60*60)
+	}
+
+	midnight := got.In(loc)
+
+	if midnight.Hour() != 0 || midnight.Minute() != 0 || midnight.Second() != 0 {
+		t.Errorf("nextMidnightKST returned %v, want 00:00:00 KST", midnight)
+	}
+
+	if got.Before(time.Now()) {
+		t.Errorf("nextMidnightKST returned a time in the past: %v", got)
+	}
+}
+
+func TestNextMidnightKSTIsInFuture(t *testing.T) {
+	now := time.Now()
+	next := nextMidnightKST()
+	if !next.After(now) {
+		t.Errorf("expected next midnight KST to be after now, got %v", next)
+	}
+	// Should be at most ~24h in the future.
+	maxFuture := now.Add(25 * time.Hour)
+	if next.After(maxFuture) {
+		t.Errorf("next midnight KST is more than 25h away: %v", next)
+	}
+}

--- a/internal/email/email.go
+++ b/internal/email/email.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/smtp"
 	"strings"
+	"time"
 )
 
 // Client sends emails via SMTP.
@@ -284,4 +285,97 @@ func (c *Client) SendInvitationEmail(to, orgName, inviterName, signupURL string)
 </html>`, inviterName, orgName, signupURL, signupURL)
 
 	return c.sendHTML(to, subject, body)
+}
+
+// ExpiringContractInfo holds minimal info about a contract for the expiry alert email.
+type ExpiringContractInfo struct {
+	Title     string
+	ExpiresAt time.Time
+}
+
+// SendExpiryAlertEmail notifies an org admin that one or more contracts are expiring soon.
+// contracts is a slice of ExpiringContractInfo describing which contracts are about to expire.
+func (c *Client) SendExpiryAlertEmail(to, orgName string, contracts []ExpiringContractInfo, alertDays int) error {
+	subject := fmt.Sprintf("[SignSafe] %s 조직 계약 만료 알림 (%d건)", orgName, len(contracts))
+
+	var rows strings.Builder
+	for _, ct := range contracts {
+		daysLeft := int(time.Until(ct.ExpiresAt).Hours() / 24)
+		daysLabel := fmt.Sprintf("D-%d", daysLeft)
+		if daysLeft == 0 {
+			daysLabel = "오늘 만료"
+		}
+		rows.WriteString(fmt.Sprintf(`
+            <tr style="border-top:1px solid #f4f4f5;">
+              <td style="padding:10px 0;font-size:13px;color:#18181b;">%s</td>
+              <td style="padding:10px 0;font-size:13px;color:#71717a;text-align:right;">%s &nbsp;<strong style="color:#dc2626;">%s</strong></td>
+            </tr>`,
+			htmlEscape(ct.Title),
+			ct.ExpiresAt.Format("2006-01-02"),
+			daysLabel,
+		))
+	}
+
+	contractsURL := fmt.Sprintf("%s/contracts", c.appURL)
+	body := fmt.Sprintf(`<!DOCTYPE html>
+<html lang="ko">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="margin:0;padding:0;background:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
+  <table width="100%%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:40px 0;">
+    <tr><td align="center">
+      <table width="520" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+        <tr>
+          <td style="background:#18181b;padding:32px 40px;">
+            <p style="margin:0;font-size:20px;font-weight:700;color:#ffffff;letter-spacing:-0.3px;">SignSafe</p>
+            <p style="margin:4px 0 0;font-size:12px;color:#a1a1aa;">계약서 리스크 분석 플랫폼</p>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:40px;">
+            <p style="margin:0 0 8px;font-size:22px;font-weight:600;color:#18181b;">계약 만료 알림</p>
+            <p style="margin:0 0 24px;font-size:14px;color:#71717a;line-height:1.6;">
+              <strong style="color:#18181b;">%s</strong> 조직에서 <strong style="color:#dc2626;">%d일 이내</strong> 만료 예정인 계약이 <strong>%d건</strong> 있습니다.
+            </p>
+            <!-- Contract list -->
+            <table width="100%%" cellpadding="0" cellspacing="0" style="margin:0 0 28px;border:1px solid #f4f4f5;border-radius:8px;overflow:hidden;">
+              <tr style="background:#f9f9f9;">
+                <td style="padding:10px 12px;font-size:11px;font-weight:600;color:#a1a1aa;text-transform:uppercase;letter-spacing:0.05em;">계약명</td>
+                <td style="padding:10px 12px;font-size:11px;font-weight:600;color:#a1a1aa;text-transform:uppercase;letter-spacing:0.05em;text-align:right;">만료일</td>
+              </tr>
+              %s
+            </table>
+            <!-- CTA -->
+            <table cellpadding="0" cellspacing="0">
+              <tr>
+                <td style="background:#18181b;border-radius:8px;">
+                  <a href="%s" style="display:inline-block;padding:12px 28px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;">계약 목록 보기</a>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:20px 40px;border-top:1px solid #f4f4f5;">
+            <p style="margin:0;font-size:12px;color:#a1a1aa;">
+              이 알림은 매일 자동 발송됩니다. SignSafe 대시보드에서 만료 설정을 관리하세요.<br>
+              © 2026 SignSafe. All rights reserved.
+            </p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`, htmlEscape(orgName), alertDays, len(contracts), rows.String(), contractsURL)
+
+	return c.sendHTML(to, subject, body)
+}
+
+// htmlEscape escapes basic HTML special characters in user-provided strings.
+func htmlEscape(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	s = strings.ReplaceAll(s, "\"", "&#34;")
+	return s
 }

--- a/internal/repository/user_repo.go
+++ b/internal/repository/user_repo.go
@@ -545,3 +545,36 @@ func (r *UserRepo) DeleteInvitation(ctx context.Context, id string) error {
 	}
 	return nil
 }
+
+// OrgAdmin holds minimal info about an organization admin.
+type OrgAdmin struct {
+	UserID string `db:"user_id"`
+	Email  string `db:"email"`
+}
+
+// ListAllOrganizations returns all organizations in the system.
+// Used by background jobs that process every org.
+func (r *UserRepo) ListAllOrganizations(ctx context.Context) ([]model.Organization, error) {
+	var orgs []model.Organization
+	err := r.db.SelectContext(ctx, &orgs, `SELECT * FROM organizations ORDER BY created_at ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("userRepo.ListAllOrganizations: %w", err)
+	}
+	return orgs, nil
+}
+
+// ListOrgAdmins returns all admin-role members of the given organization.
+func (r *UserRepo) ListOrgAdmins(ctx context.Context, orgID string) ([]OrgAdmin, error) {
+	var admins []OrgAdmin
+	err := r.db.SelectContext(ctx, &admins, `
+		SELECT uo.user_id, u.email
+		FROM user_organizations uo
+		JOIN users u ON u.id = uo.user_id
+		WHERE uo.organization_id = $1
+		  AND uo.role = 'admin'
+		ORDER BY uo.joined_at ASC`, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("userRepo.ListOrgAdmins: %w", err)
+	}
+	return admins, nil
+}


### PR DESCRIPTION
## 변경사항
- internal/cron/expiry_notifier.go: ExpiryNotifier 구현
- internal/email/email.go: SendExpiryAlertEmail 추가
- internal/repository/user_repo.go: ListAllOrganizations, ListOrgAdmins 추가
- cmd/server/main.go: ExpiryNotifier 고루틴, EXPIRY_ALERT_DAYS 환경변수
- internal/cron/expiry_notifier_test.go: nextMidnightKST 테스트 PASS

Closes #116