### PR TITLE
feat(#118): 대시보드 만료 구간별 통계 (30/60/90일) + confidence score 마이그레이션

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -122,3 +122,29 @@
 - `audit_handler.go`의 인라인 IP 추출 코드도 `clientIP()` helper로 대체
 
 **영향**: 없음 (동작 동일)
+
+---
+
+## 2026-04-01: 대시보드 만료 구간별 통계 추가
+
+**결정**: `GET /organizations/{orgId}/stats` 응답에 `expiryBuckets { days30, days60, days90 }` 추가.
+
+**이유**:
+- 기존 `expiringSoon`(30일)만으로는 계약 갱신 우선순위 판단 부족
+- 30/60/90일 구간을 단일 SQL 쿼리(`COUNT(*) FILTER (WHERE ...)` 3개)로 추가 → 쿼리 수 변동 없음
+- 기존 `expiringSoon` 필드는 하위 호환을 위해 유지 (`= expiring30` 값)
+
+**영향**: 마이그레이션 불필요 (DB 스키마 변경 없음, SQL 집계만 변경)
+
+---
+
+## 2026-04-01: confidence score 마이그레이션
+
+**결정**: `clause_results.confidence FLOAT NOT NULL DEFAULT 0.5` 컬럼 추가 (migration 000006).
+
+**이유**:
+- signsafe-ai LLM 분석 결과에 신뢰도 0~1 포함
+- 기존 행에는 DEFAULT 0.5 적용 (중립값)
+- NOT NULL로 선언하여 API 응답에서 null 처리 불필요
+
+**영향**: signsafe-ai `insert_clause_result` SQL 업데이트 필요 (완료)

--- a/internal/model/analysis.go
+++ b/internal/model/analysis.go
@@ -16,23 +16,24 @@ type RiskAnalysis struct {
 }
 
 type ClauseResult struct {
-	ID                   string     `db:"id" json:"id"`
-	AnalysisID           string     `db:"analysis_id" json:"analysisId"`
-	ClauseID             string     `db:"clause_id" json:"clauseId"`
-	RiskLevel            string     `db:"risk_level" json:"riskLevel"`
-	IssueType            *string    `db:"issue_type" json:"issueType"`
-	Summary              *string    `db:"summary" json:"summary"`
-	HighlightX           *float64   `db:"highlight_x" json:"highlightX"`
-	HighlightY           *float64   `db:"highlight_y" json:"highlightY"`
-	HighlightWidth       *float64   `db:"highlight_width" json:"highlightWidth"`
-	HighlightHeight      *float64   `db:"highlight_height" json:"highlightHeight"`
-	PageNumber           *int       `db:"page_number" json:"pageNumber"`
-	OverriddenRiskLevel  *string    `db:"overridden_risk_level" json:"overriddenRiskLevel"`
-	OverrideReason       *string    `db:"override_reason" json:"overrideReason"`
-	OverriddenBy         *string    `db:"overridden_by" json:"overriddenBy"`
-	OverriddenAt         *time.Time `db:"overridden_at" json:"overriddenAt"`
-	CreatedAt            time.Time  `db:"created_at" json:"createdAt"`
-	UpdatedAt            time.Time  `db:"updated_at" json:"updatedAt"`
+	ID                  string     `db:"id" json:"id"`
+	AnalysisID          string     `db:"analysis_id" json:"analysisId"`
+	ClauseID            string     `db:"clause_id" json:"clauseId"`
+	RiskLevel           string     `db:"risk_level" json:"riskLevel"`
+	Confidence          float64    `db:"confidence" json:"confidence"`
+	IssueType           *string    `db:"issue_type" json:"issueType"`
+	Summary             *string    `db:"summary" json:"summary"`
+	HighlightX          *float64   `db:"highlight_x" json:"highlightX"`
+	HighlightY          *float64   `db:"highlight_y" json:"highlightY"`
+	HighlightWidth      *float64   `db:"highlight_width" json:"highlightWidth"`
+	HighlightHeight     *float64   `db:"highlight_height" json:"highlightHeight"`
+	PageNumber          *int       `db:"page_number" json:"pageNumber"`
+	OverriddenRiskLevel *string    `db:"overridden_risk_level" json:"overriddenRiskLevel"`
+	OverrideReason      *string    `db:"override_reason" json:"overrideReason"`
+	OverriddenBy        *string    `db:"overridden_by" json:"overriddenBy"`
+	OverriddenAt        *time.Time `db:"overridden_at" json:"overriddenAt"`
+	CreatedAt           time.Time  `db:"created_at" json:"createdAt"`
+	UpdatedAt           time.Time  `db:"updated_at" json:"updatedAt"`
 }
 
 type EvidenceSet struct {

--- a/internal/repository/stats_repo.go
+++ b/internal/repository/stats_repo.go
@@ -15,7 +15,10 @@ type OrgStats struct {
 	ReadyContracts      int `db:"ready_contracts"      json:"readyContracts"`
 	FailedContracts     int `db:"failed_contracts"     json:"failedContracts"`
 	RecentAnalyses      int `db:"recent_analyses"      json:"recentAnalyses"` // last 30 days
-	ExpiringSoon        int `db:"expiring_soon"        json:"expiringSoon"`   // expires within 30 days
+	ExpiringSoon        int `db:"expiring_soon"        json:"expiringSoon"`   // expires within 30 days (= Expiring30)
+	Expiring30          int `db:"expiring_30"          json:"expiring30"`     // expires within 30 days
+	Expiring60          int `db:"expiring_60"          json:"expiring60"`     // expires within 60 days
+	Expiring90          int `db:"expiring_90"          json:"expiring90"`     // expires within 90 days
 }
 
 // RiskDistribution holds the count of clause results at each risk level for an org.
@@ -44,6 +47,8 @@ func NewStatsRepo(db *sqlx.DB) *StatsRepo {
 }
 
 // GetOrgStats returns contract counts and recent analysis count for an org.
+// Expiry buckets count contracts expiring within 30/60/90 days from now.
+// Already-expired contracts are excluded from all buckets.
 func (r *StatsRepo) GetOrgStats(ctx context.Context, orgID string) (*OrgStats, error) {
 	var s OrgStats
 	err := r.db.GetContext(ctx, &s, `
@@ -64,7 +69,22 @@ func (r *StatsRepo) GetOrgStats(ctx context.Context, orgID string) (*OrgStats, e
 				WHERE expires_at IS NOT NULL
 				  AND expires_at > NOW()
 				  AND expires_at <= NOW() + INTERVAL '30 days'
-			)                                                                AS expiring_soon
+			)                                                                AS expiring_soon,
+			COUNT(*) FILTER (
+				WHERE expires_at IS NOT NULL
+				  AND expires_at > NOW()
+				  AND expires_at <= NOW() + INTERVAL '30 days'
+			)                                                                AS expiring_30,
+			COUNT(*) FILTER (
+				WHERE expires_at IS NOT NULL
+				  AND expires_at > NOW()
+				  AND expires_at <= NOW() + INTERVAL '60 days'
+			)                                                                AS expiring_60,
+			COUNT(*) FILTER (
+				WHERE expires_at IS NOT NULL
+				  AND expires_at > NOW()
+				  AND expires_at <= NOW() + INTERVAL '90 days'
+			)                                                                AS expiring_90
 		FROM contracts
 		WHERE organization_id = $1`,
 		orgID)

--- a/internal/service/stats_service.go
+++ b/internal/service/stats_service.go
@@ -7,6 +7,13 @@ import (
 	"github.com/signsafe-io/signsafe-api/internal/repository"
 )
 
+// ExpiryBuckets holds contract counts expiring within 30, 60, and 90 days.
+type ExpiryBuckets struct {
+	Days30 int `json:"days30"`
+	Days60 int `json:"days60"`
+	Days90 int `json:"days90"`
+}
+
 // DashboardStats is the full response for the dashboard statistics endpoint.
 type DashboardStats struct {
 	TotalContracts      int                         `json:"totalContracts"`
@@ -15,7 +22,8 @@ type DashboardStats struct {
 	ReadyContracts      int                         `json:"readyContracts"`
 	FailedContracts     int                         `json:"failedContracts"`
 	RecentAnalyses      int                         `json:"recentAnalyses"`
-	ExpiringSoon        int                         `json:"expiringSoon"` // expires within 30 days
+	ExpiringSoon        int                         `json:"expiringSoon"` // = ExpiryBuckets.Days30, kept for backward compat
+	ExpiryBuckets       ExpiryBuckets               `json:"expiryBuckets"`
 	RiskDistribution    repository.RiskDistribution `json:"riskDistribution"`
 	RecentContracts     []repository.RecentContract `json:"recentContracts"`
 }
@@ -69,7 +77,12 @@ func (s *StatsService) GetDashboardStats(ctx context.Context, userID, orgID stri
 		FailedContracts:     orgStats.FailedContracts,
 		RecentAnalyses:      orgStats.RecentAnalyses,
 		ExpiringSoon:        orgStats.ExpiringSoon,
-		RiskDistribution:    *riskDist,
-		RecentContracts:     recentContracts,
+		ExpiryBuckets: ExpiryBuckets{
+			Days30: orgStats.Expiring30,
+			Days60: orgStats.Expiring60,
+			Days90: orgStats.Expiring90,
+		},
+		RiskDistribution: *riskDist,
+		RecentContracts:  recentContracts,
 	}, nil
 }

--- a/migrations/000006_clause_results_confidence.down.sql
+++ b/migrations/000006_clause_results_confidence.down.sql
@@ -1,0 +1,2 @@
+-- 000006_clause_results_confidence.down.sql
+ALTER TABLE clause_results DROP COLUMN IF EXISTS confidence;

--- a/migrations/000006_clause_results_confidence.up.sql
+++ b/migrations/000006_clause_results_confidence.up.sql
@@ -1,0 +1,10 @@
+-- 000006_clause_results_confidence.up.sql
+-- Add confidence score column to clause_results.
+-- confidence: 0.0~1.0 float representing the LLM's certainty about the risk assessment.
+-- Defaults to 0.5 (neutral) for existing rows and future rows where confidence is not provided.
+
+ALTER TABLE clause_results
+    ADD COLUMN IF NOT EXISTS confidence FLOAT NOT NULL DEFAULT 0.5;
+
+COMMENT ON COLUMN clause_results.confidence IS
+    'LLM risk-level confidence score (0.0 = uncertain, 1.0 = highly certain). Default 0.5.';


### PR DESCRIPTION
## 변경사항

### 만료 구간별 통계 (issue #118)
- `OrgStats` 구조체에 `Expiring30`, `Expiring60`, `Expiring90` int 필드 추가
- `GetOrgStats` SQL: `COUNT(*) FILTER` 3개 추가 (단일 쿼리, 추가 DB 왕복 없음)
- `DashboardStats` 응답에 `expiryBuckets: { days30, days60, days90 }` 추가
- 기존 `expiringSoon` 필드 유지 (하위 호환, `= expiring30` 값)

### Confidence score DB 마이그레이션
- `migrations/000006_clause_results_confidence.up.sql`: `clause_results.confidence FLOAT NOT NULL DEFAULT 0.5`
- `migrations/000006_clause_results_confidence.down.sql`: DROP COLUMN
- `model.ClauseResult`: `Confidence float64` 필드 추가 (`json:"confidence"`)
- signsafe-ai 워커가 이 컬럼에 LLM confidence 값을 저장 (별도 PR)

## QA 결과
- `go build ./...`: PASS
- `go vet ./...`: PASS
- `go test ./internal/...`: PASS (cron 테스트 통과, 나머지 no test files)
- 기존 expiringSoon 필드 하위 호환 유지 확인

Closes #118