### PR TITLE
fix(#125): EvidenceSet Citations/RecommendedActions JSONB → json.RawMessage

### DIFF
--- a/internal/model/analysis.go
+++ b/internal/model/analysis.go
@@ -43,16 +43,16 @@ type ClauseResult struct {
 }
 
 type EvidenceSet struct {
-	ID                 string    `db:"id" json:"id"`
-	ClauseResultID     string    `db:"clause_result_id" json:"clauseResultId"`
-	Rationale          string    `db:"rationale" json:"rationale"`
-	Citations          string    `db:"citations" json:"citations"`
-	RecommendedActions string    `db:"recommended_actions" json:"recommendedActions"`
-	TopK               int       `db:"top_k" json:"topK"`
-	FilterParams       string    `db:"filter_params" json:"filterParams"`
-	RetrievedAt        time.Time `db:"retrieved_at" json:"retrievedAt"`
-	CreatedAt          time.Time `db:"created_at" json:"createdAt"`
-	UpdatedAt          time.Time `db:"updated_at" json:"updatedAt"`
+	ID                 string          `db:"id" json:"id"`
+	ClauseResultID     string          `db:"clause_result_id" json:"clauseResultId"`
+	Rationale          string          `db:"rationale" json:"rationale"`
+	Citations          json.RawMessage `db:"citations" json:"citations"`
+	RecommendedActions json.RawMessage `db:"recommended_actions" json:"recommendedActions"`
+	TopK               int             `db:"top_k" json:"topK"`
+	FilterParams       json.RawMessage `db:"filter_params" json:"filterParams"`
+	RetrievedAt        time.Time       `db:"retrieved_at" json:"retrievedAt"`
+	CreatedAt          time.Time       `db:"created_at" json:"createdAt"`
+	UpdatedAt          time.Time       `db:"updated_at" json:"updatedAt"`
 }
 
 type RiskOverride struct {


### PR DESCRIPTION
## 변경사항
- `EvidenceSet.Citations` `string` → `json.RawMessage`
- `EvidenceSet.RecommendedActions` `string` → `json.RawMessage`
- `EvidenceSet.FilterParams` `string` → `json.RawMessage`

## 배경
DB의 `citations`, `recommended_actions`, `filter_params`는 JSONB 타입이지만
Go 모델에서 `string`으로 선언되어 있어 API 응답에서 배열/객체가 문자열로
이중 직렬화되는 버그가 있었음. 프론트엔드에서 `parseCitations(raw: string)`로
`JSON.parse` 워크어라운드를 사용하고 있었음.

`json.RawMessage`로 변경하면 sqlx가 JSONB를 바이트 슬라이스로 스캔하여
`encoding/json`이 그대로 배열/객체로 직렬화함.

## QA 결과
- `go build ./...` 통과
- `go vet ./...` 통과

Closes #125