### PR TITLE
feat(#127): 계약서 목록에 latestAnalysisRisk 포함

### DIFF
--- a/internal/model/contract.go
+++ b/internal/model/contract.go
@@ -20,6 +20,9 @@ type Contract struct {
 	ExpiresAt      *time.Time `db:"expires_at" json:"expiresAt"`
 	CreatedAt      time.Time  `db:"created_at" json:"createdAt"`
 	UpdatedAt      time.Time  `db:"updated_at" json:"updatedAt"`
+	// LatestAnalysisRisk is populated only by list queries (LEFT JOIN risk_analyses).
+	// Null when no completed analysis exists for this contract.
+	LatestAnalysisRisk *string `db:"latest_analysis_risk" json:"latestAnalysisRisk,omitempty"`
 }
 
 type IngestionJob struct {

--- a/internal/repository/contract_repo.go
+++ b/internal/repository/contract_repo.go
@@ -97,11 +97,26 @@ func (r *ContractRepo) ListContracts(ctx context.Context, orgID string, limit, o
 
 	listArgs := append(args, limit, offset)
 	var contracts []model.Contract
+	// Subquery paginates the contracts, then LATERAL JOIN adds the latest
+	// completed overall_risk per contract (null when no completed analysis exists).
 	err := r.db.SelectContext(ctx, &contracts, fmt.Sprintf(`
-		SELECT * FROM contracts
-		WHERE %s
-		ORDER BY created_at DESC
-		LIMIT $%d OFFSET $%d`, whereClause, argIdx, argIdx+1),
+		SELECT c.*,
+		       ra.overall_risk AS latest_analysis_risk
+		FROM (
+		    SELECT * FROM contracts
+		    WHERE %s
+		    ORDER BY created_at DESC
+		    LIMIT $%d OFFSET $%d
+		) c
+		LEFT JOIN LATERAL (
+		    SELECT overall_risk
+		    FROM risk_analyses
+		    WHERE contract_id = c.id
+		      AND status = 'completed'
+		    ORDER BY created_at DESC
+		    LIMIT 1
+		) ra ON true
+		ORDER BY c.created_at DESC`, whereClause, argIdx, argIdx+1),
 		listArgs...)
 	if err != nil {
 		return nil, 0, fmt.Errorf("contractRepo.ListContracts: %w", err)


### PR DESCRIPTION
## 변경사항
- `Contract` 모델에 `LatestAnalysisRisk *string` 필드 추가
- `ListContracts` 쿼리에서 LATERAL JOIN으로 각 계약의 최신 완료 분석 `overall_risk` 포함
- 분석이 없거나 `completed` 상태가 아니면 `null` 반환 (`omitempty`)

## SQL 전략
서브쿼리로 계약 목록을 페이지네이션한 뒤 LATERAL JOIN으로 최신 분석을 붙임.
- 기존 WHERE 절 조건(검색, 상태 필터)은 서브쿼리 안에서 처리하므로 컬럼 별칭 충돌 없음
- risk_analyses 인덱스(`contract_id, status, created_at`) 사용으로 서브쿼리 성능 양호

## QA 결과
- `go build ./...` 통과
- `go vet ./...` 통과

Closes #127