### PR TITLE
chore: risk_analyses 복합 인덱스 추가 (contract_id, status, created_at)

### DIFF
--- a/migrations/000008_risk_analyses_composite_index.down.sql
+++ b/migrations/000008_risk_analyses_composite_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_risk_analyses_contract_status_created;

--- a/migrations/000008_risk_analyses_composite_index.up.sql
+++ b/migrations/000008_risk_analyses_composite_index.up.sql
@@ -1,0 +1,5 @@
+-- Composite index for LATERAL JOIN in ListContracts:
+--   WHERE contract_id = ? AND status = 'completed' ORDER BY created_at DESC LIMIT 1
+-- Without this, Postgres uses idx_risk_analyses_contract_id and scans all rows per contract.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_risk_analyses_contract_status_created
+    ON risk_analyses (contract_id, status, created_at DESC);


### PR DESCRIPTION
## 배경
PR #128 `ListContracts` LATERAL JOIN 쿼리:
```sql
SELECT overall_risk FROM risk_analyses
WHERE contract_id = c.id AND status = 'completed'
ORDER BY created_at DESC LIMIT 1
```
기존 인덱스: `(contract_id)`, `(status)` 각각 단일 인덱스만 존재.
→ PostgreSQL이 `contract_id` 인덱스로 스캔 후 나머지를 필터링하지만 ORDER BY를 위한 정렬이 추가로 발생함.

## 변경사항
복합 인덱스 `(contract_id, status, created_at DESC)` 추가.
- `CONCURRENTLY`로 생성하여 운영 중 테이블 락 없음
- `LIMIT 1`과 결합하면 index scan 한 번으로 최신 완료 분석 결과 조회 가능