### PR TITLE
fix(#134): wrap sentinel errors with %w in EvidenceService and ContractService

### DIFF
--- a/internal/service/contract_service.go
+++ b/internal/service/contract_service.go
@@ -116,14 +116,14 @@ func (s *ContractService) GetIngestionJob(ctx context.Context, jobID, requestedB
 		return nil, fmt.Errorf("contractService.GetIngestionJob: find contract: %w", err)
 	}
 	if c == nil {
-		return nil, fmt.Errorf("contractService.GetIngestionJob: contract not found")
+		return nil, fmt.Errorf("contractService.GetIngestionJob: contract not found: %w", ErrNotFound)
 	}
 	member, err := s.userRepo.IsOrgMember(ctx, requestedBy, c.OrganizationID)
 	if err != nil {
 		return nil, fmt.Errorf("contractService.GetIngestionJob: check membership: %w", err)
 	}
 	if !member {
-		return nil, fmt.Errorf("contractService.GetIngestionJob: access denied")
+		return nil, fmt.Errorf("contractService.GetIngestionJob: %w", ErrAccessDenied)
 	}
 
 	return job, nil
@@ -137,7 +137,7 @@ func (s *ContractService) ListIngestionJobsByContract(ctx context.Context, contr
 		return nil, fmt.Errorf("contractService.ListIngestionJobsByContract: find contract: %w", err)
 	}
 	if c == nil {
-		return nil, fmt.Errorf("contractService.ListIngestionJobsByContract: contract not found")
+		return nil, fmt.Errorf("contractService.ListIngestionJobsByContract: contract not found: %w", ErrNotFound)
 	}
 
 	member, err := s.userRepo.IsOrgMember(ctx, requestedBy, c.OrganizationID)
@@ -145,7 +145,7 @@ func (s *ContractService) ListIngestionJobsByContract(ctx context.Context, contr
 		return nil, fmt.Errorf("contractService.ListIngestionJobsByContract: check membership: %w", err)
 	}
 	if !member {
-		return nil, fmt.Errorf("contractService.ListIngestionJobsByContract: access denied")
+		return nil, fmt.Errorf("contractService.ListIngestionJobsByContract: %w", ErrAccessDenied)
 	}
 
 	jobs, err := s.repo.ListIngestionJobsByContractID(ctx, contractID)
@@ -257,7 +257,7 @@ func (s *ContractService) UpdateContract(ctx context.Context, contractID, reques
 		return nil, fmt.Errorf("contractService.UpdateContract: %w", err)
 	}
 	if c == nil {
-		return nil, fmt.Errorf("contractService.UpdateContract: contract not found")
+		return nil, fmt.Errorf("contractService.UpdateContract: contract not found: %w", ErrNotFound)
 	}
 
 	member, err := s.userRepo.IsOrgMember(ctx, requestedBy, c.OrganizationID)
@@ -265,7 +265,7 @@ func (s *ContractService) UpdateContract(ctx context.Context, contractID, reques
 		return nil, fmt.Errorf("contractService.UpdateContract: check membership: %w", err)
 	}
 	if !member {
-		return nil, fmt.Errorf("contractService.UpdateContract: access denied")
+		return nil, fmt.Errorf("contractService.UpdateContract: %w", ErrAccessDenied)
 	}
 
 	updates := repository.ContractUpdate{
@@ -308,7 +308,7 @@ func (s *ContractService) DeleteContract(ctx context.Context, contractID, reques
 		return fmt.Errorf("contractService.DeleteContract: %w", err)
 	}
 	if c == nil {
-		return fmt.Errorf("contractService.DeleteContract: contract not found")
+		return fmt.Errorf("contractService.DeleteContract: contract not found: %w", ErrNotFound)
 	}
 
 	member, err := s.userRepo.IsOrgMember(ctx, requestedBy, c.OrganizationID)
@@ -316,7 +316,7 @@ func (s *ContractService) DeleteContract(ctx context.Context, contractID, reques
 		return fmt.Errorf("contractService.DeleteContract: check membership: %w", err)
 	}
 	if !member {
-		return fmt.Errorf("contractService.DeleteContract: access denied")
+		return fmt.Errorf("contractService.DeleteContract: %w", ErrAccessDenied)
 	}
 
 	// Delete from storage (best-effort; DB row is the authoritative record).
@@ -341,7 +341,7 @@ func (s *ContractService) GetFile(ctx context.Context, contractID string) (io.Re
 		return nil, "", fmt.Errorf("contractService.GetFile: %w", err)
 	}
 	if c == nil {
-		return nil, "", fmt.Errorf("contractService.GetFile: contract not found")
+		return nil, "", fmt.Errorf("contractService.GetFile: contract not found: %w", ErrNotFound)
 	}
 
 	body, err := s.storageClient.Get(ctx, c.FilePath)

--- a/internal/service/evidence_service.go
+++ b/internal/service/evidence_service.go
@@ -44,7 +44,7 @@ func (s *EvidenceService) checkEvidenceSetAccess(ctx context.Context, es *model.
 		return fmt.Errorf("find clause result: %w", err)
 	}
 	if cr == nil {
-		return fmt.Errorf("clause result not found")
+		return fmt.Errorf("clause result not found: %w", ErrNotFound)
 	}
 
 	a, err := s.analysisRepo.FindAnalysisByID(ctx, cr.AnalysisID)
@@ -52,7 +52,7 @@ func (s *EvidenceService) checkEvidenceSetAccess(ctx context.Context, es *model.
 		return fmt.Errorf("find analysis: %w", err)
 	}
 	if a == nil {
-		return fmt.Errorf("analysis not found")
+		return fmt.Errorf("analysis not found: %w", ErrNotFound)
 	}
 
 	c, err := s.contractRepo.FindContractByID(ctx, a.ContractID)
@@ -60,7 +60,7 @@ func (s *EvidenceService) checkEvidenceSetAccess(ctx context.Context, es *model.
 		return fmt.Errorf("find contract: %w", err)
 	}
 	if c == nil {
-		return fmt.Errorf("contract not found")
+		return fmt.Errorf("contract not found: %w", ErrNotFound)
 	}
 
 	member, err := s.userRepo.IsOrgMember(ctx, userID, c.OrganizationID)
@@ -68,7 +68,7 @@ func (s *EvidenceService) checkEvidenceSetAccess(ctx context.Context, es *model.
 		return fmt.Errorf("check membership: %w", err)
 	}
 	if !member {
-		return fmt.Errorf("access denied")
+		return fmt.Errorf("%w", ErrAccessDenied)
 	}
 	return nil
 }
@@ -100,7 +100,7 @@ func (s *EvidenceService) RetrieveEvidence(ctx context.Context, evidenceSetID st
 		return fmt.Errorf("evidenceService.RetrieveEvidence: %w", err)
 	}
 	if es == nil {
-		return fmt.Errorf("evidenceService.RetrieveEvidence: evidence set not found")
+		return fmt.Errorf("evidenceService.RetrieveEvidence: evidence set not found: %w", ErrNotFound)
 	}
 
 	if err := s.checkEvidenceSetAccess(ctx, es, userID); err != nil {


### PR DESCRIPTION
## 변경사항
- `evidence_service.go` `checkEvidenceSetAccess`: clause result / analysis / contract not found → `ErrNotFound` 래핑; access denied → `ErrAccessDenied` 래핑
- `evidence_service.go` `RetrieveEvidence`: evidence set not found → `ErrNotFound` 래핑
- `contract_service.go` `GetIngestionJob`: contract not found / access denied sentinel 래핑
- `contract_service.go` `ListIngestionJobsByContract`: contract not found / access denied sentinel 래핑
- `contract_service.go` `UpdateContract`: contract not found / access denied sentinel 래핑
- `contract_service.go` `DeleteContract`: contract not found / access denied sentinel 래핑
- `contract_service.go` `GetFile`: contract not found sentinel 래핑

## 원인
`fmt.Errorf("contract not found")` 처럼 `%w` 없이 평문 문자열로 에러를 생성하면
handler에서 `errors.Is(err, service.ErrNotFound)` 체크가 항상 false를 반환함.
결과적으로 404/403 대신 항상 500이 응답되던 버그.

## QA
- `go build ./...` 통과

Closes #134